### PR TITLE
chore: add contributing guidelines and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,11 @@
+<!--
+Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
+-->
+
+## What does this PR do?
+
+<!-- Briefly describe what are the changes proposed in this PR, and highlight any breaking change. -->
+
+## Related issues
+
+<!-- Link related issues below. Insert the issue link or reference -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to WIPP
+
+## Development flow
+
+### Fork & Pull Request Workflow
+
+To submit a change:
+* Fork this repository to your personal account
+* Clone the forked repository
+* In most cases, the changes should be made in a new branch branched of the *develop* branch (see the [Gitflow Workflow section](#gitflow-workflow) below)
+* Submit a Pull Request (PR) to merge your changes into the *develop* branch of this repository
+* One the repository maintainers will review the PR, usually within 48 hours
+
+### Gitflow Workflow
+
+The WIPP repositories are managed following the [Gitflow Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow):
+* The *master* branch is for releases only
+* All new development occurs on their own branches, the name of the new branch will usually start with 'feature/', 'fix/', 'chore/' or 'doc/' to indicate the type of change
+* Branches start from the *develop* branch base
+
+## Styleguides
+
+### Git Commit Messages
+
+* Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/) convention to format commit messages
+* Use the present tense ("Add feature" not "Added feature")
+* Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+* Squash commits before submitting the PR if needed
+
+### Java Coding Conventions
+
+* Follow the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html) conventions


### PR DESCRIPTION
This is a starting point for setting contributing guidelines for the WIPP repositories, and is meant to be improved as we go.

Includes:
- CONTRIBUTING file
- simple PR template

PS: this PR is opened for the master branch on purpose, in order to have the PR template available right away, but we can rebase once it is merged

