### PR TITLE
feat: add visualizations management

### DIFF
--- a/wipp-backend-application/pom.xml
+++ b/wipp-backend-application/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.4.RELEASE</version>
+		<version>2.0.3.RELEASE</version>
 		<relativePath></relativePath>
 	</parent>
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/Visualization.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/Visualization.java
@@ -1,0 +1,68 @@
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.data.visualization;
+
+import java.util.Date;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import gov.nist.itl.ssd.wipp.backend.core.rest.annotation.IdExposed;
+import gov.nist.itl.ssd.wipp.backend.data.visualization.manifest.Manifest;
+
+/**
+ *
+ * @author Antoine Vandecreme <antoine.vandecreme at nist.gov>
+ */
+@Document
+@IdExposed
+public class Visualization {
+
+    @Id
+    private String id;
+
+    private String name;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private Date creationDate;
+
+    private Manifest manifest;
+
+    public String getId() {
+        return id;
+    }
+    
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Date getCreationDate() {
+        return creationDate;
+    }
+
+    void setCreationDate(Date creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    public Manifest getManifest() {
+        return manifest;
+    }
+
+    public void setManifest(Manifest manifest) {
+        this.manifest = manifest;
+    }
+
+}

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/VisualizationDownloadController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/VisualizationDownloadController.java
@@ -1,0 +1,228 @@
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.data.visualization;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.io.IOUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
+import gov.nist.itl.ssd.wipp.backend.data.pyramid.Pyramid;
+import gov.nist.itl.ssd.wipp.backend.data.pyramid.PyramidRepository;
+import gov.nist.itl.ssd.wipp.backend.data.pyramid.timeslices.PyramidTimeSlice;
+import gov.nist.itl.ssd.wipp.backend.data.pyramid.timeslices.PyramidTimeSliceRepository;
+import gov.nist.itl.ssd.wipp.backend.data.visualization.manifest.Manifest;
+
+/**
+ * Controller for downloading visualization, returns a ZIP folder with pyramids + manifest
+ * 
+ * @author Mylene Simon <mylene.simon at nist.gov>
+ *
+ */
+@Controller
+@RequestMapping(CoreConfig.BASE_URI + "/visualizations/{visualizationId}/download")
+public class VisualizationDownloadController {
+
+	@Autowired
+	CoreConfig config;
+	
+	@Autowired
+    private VisualizationRepository visualizationRepository;
+	
+	@Autowired
+    private PyramidRepository pyramidRepository;
+	
+	@Autowired
+    private PyramidTimeSliceRepository pyramidTimeSliceRepository;
+	
+	@RequestMapping(
+            value = "",
+            method = RequestMethod.GET,
+            produces = "application/zip")
+    public void get(
+            @PathVariable("visualizationId") String visualizationId,
+            HttpServletResponse response) throws IOException {
+        
+		Visualization visualization = null;
+		Optional<Visualization> optionalVisualization = visualizationRepository.findById(visualizationId);
+		
+		if (!optionalVisualization.isPresent()) {
+			throw new ResourceNotFoundException(
+					"Visualization " + visualizationId + " not found.");
+		} else {
+			visualization = optionalVisualization.get();
+		}
+		
+		Manifest manifest = visualization.getManifest();
+		
+		if (manifest == null) {
+			throw new ResourceNotFoundException(
+					"No manifest found for visualization " + visualizationId + ".");
+		}
+		
+        response.setHeader("Content-disposition",
+                "attachment;filename=" + visualization.getName() + ".zip");
+
+        ZipOutputStream zos = new ZipOutputStream(response.getOutputStream());
+        
+        // add pyramids used for the visualization
+        List<String> pyramidIds = getListOfPyramidIdsAndCurateManifest(manifest);
+        for (int i=0; i < pyramidIds.size(); i++) {
+        	addPyramidToZipOutputStream(zos, pyramidIds.get(i));
+        }
+        
+        // add manifest and README file
+        try (PrintWriter printWriter = new PrintWriter(zos)) {
+        	// manifest (curated with generic paths for the pyramids URLs)
+            zos.putNextEntry(new ZipEntry("/visualization/manifest.json"));
+        	ObjectMapper mapper = new ObjectMapper();
+        	mapper.disable(MapperFeature.USE_ANNOTATIONS);
+			printWriter.write(mapper.writerWithDefaultPrettyPrinter()
+					.writeValueAsString(manifest));
+			printWriter.flush();
+			// README
+	        zos.putNextEntry(new ZipEntry("/visualization/README.txt"));
+	        printWriter.write(generateREADME());
+        }
+        
+    }
+	
+	/**
+	 * Retrieves list of pyramidIds used for the visualization from manifest,
+	 * and curates manifest to be used outside of WIPP
+	 * @param manifest Visualization manifest
+	 * @return List of pyramidIds
+	 */
+	private List<String> getListOfPyramidIdsAndCurateManifest(Manifest manifest) {
+		
+		List<String> pyramidIds = new ArrayList<String>();
+		
+		if(manifest != null && manifest.getLayersGroups() != null) {
+    		manifest.getLayersGroups().forEach(layersGroup -> {
+    			if (layersGroup != null && layersGroup.getLayers() != null) {
+    				layersGroup.getLayers().forEach(layer -> {
+    					// get the pyramidId for the layer and add it to the list of pyramids to export
+    					String pyramidId = layer.getBaseUrl();
+    					if (! pyramidIds.contains(pyramidId)) {
+    						pyramidIds.add(pyramidId);
+    					}
+    					// curate pyramid base url and fetching info for export
+    					layer.setBaseUrl("data/pyramids/" + pyramidId);
+    					layer.setFetching(null); // no fetching available for standalone wdzt instance
+    				});
+    			}
+    		});
+    	}
+		return pyramidIds;
+	}
+	
+	/**
+	 * Add pyramid files (tiles, dzi and ome.xml metadata) to the ZipOutputStream
+	 * @param zos
+	 * @param pyramidId
+	 * @throws IOException
+	 */
+	private void addPyramidToZipOutputStream(ZipOutputStream zos, String pyramidId) throws IOException {
+		
+		Pyramid pyramid = null;
+		Optional<Pyramid> optionalPyramid = pyramidRepository.findById(
+				pyramidId);
+		if (!optionalPyramid.isPresent()) {
+		    throw new ResourceNotFoundException(
+		            "Pyramid " + pyramidId + " not found.");
+		} else {
+			pyramid = optionalPyramid.get();
+		}
+		
+		List<PyramidTimeSlice> ptsList = pyramidTimeSliceRepository.findAll(pyramid.getId());
+		for (PyramidTimeSlice pts : ptsList) {
+			String sliceNumber = pts.getName();
+			// add DZI file
+			File dziFile = new File(
+	                new File(config.getPyramidsFolder(), pyramid.getId()),
+	                sliceNumber + ".dzi");
+			addFileToZos(zos, dziFile, "/visualization/pyramids/" + pyramidId + "/" + sliceNumber + ".dzi");
+
+			// add OME XML file
+	        File omeXmlFile = new File(
+	                new File(config.getPyramidsFolder(), pyramid.getId()),
+	                sliceNumber + ".ome.xml");
+	        addFileToZos(zos, omeXmlFile, "/visualization/pyramids/" + pyramidId + "/" + sliceNumber + ".ome.xml");
+
+			// add pyramid tiles
+	        File tilesFolder = new File(
+	        		new File(config.getPyramidsFolder(), pyramid.getId()), 
+	        		sliceNumber + "_files");
+	        String pathSuffixInZip = "/visualization/pyramids/" + pyramidId + "/" + tilesFolder.getName();
+	        File[] levels = tilesFolder.listFiles(File::isDirectory);
+	        for (File level : levels) {
+	        	String levelName = level.getName();
+	        	File[] tiles = level.listFiles(File::isFile);
+	        	for (File tile : tiles) {
+	        		addFileToZos(zos, tile, pathSuffixInZip + "/" + levelName + "/" + tile.getName());
+	        	}
+	        }
+		}
+		
+		
+	}
+	
+	/**
+	 * Generates README file
+	 * @return
+	 */
+	private String generateREADME() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("PYRAMID VISUALIZATION").append('\n');
+        sb.append("Check out the instructions at https://hub.docker.com/r/wipp/wdzt to visualize the pyramids ");
+        sb.append("using the WDZT Docker.");
+        sb.append('\n');
+        return sb.toString();
+    }
+	
+	/**
+	 * Adds a file to the ZipOutputStream
+	 * @param zos
+	 * @param file
+	 * @param entryName
+	 * @throws FileNotFoundException
+	 * @throws IOException
+	 */
+	private void addFileToZos(ZipOutputStream zos, File file, String entryName) throws FileNotFoundException, IOException {
+		zos.putNextEntry(new ZipEntry(entryName));
+	       try (InputStream is = new FileInputStream(file)) {
+	            IOUtils.copyLarge(is, zos);
+	        }
+	}
+}
+

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/VisualizationEventHandler.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/VisualizationEventHandler.java
@@ -1,0 +1,32 @@
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.data.visualization;
+
+import java.util.Date;
+import org.springframework.data.rest.core.annotation.HandleBeforeCreate;
+import org.springframework.data.rest.core.annotation.RepositoryEventHandler;
+import org.springframework.stereotype.Component;
+
+/**
+ *
+ * @author Antoine Vandecreme <antoine.vandecreme at nist.gov>
+ */
+@Component
+@RepositoryEventHandler(Visualization.class)
+public class VisualizationEventHandler {
+
+    @HandleBeforeCreate
+    public void handleBeforeCreate(Visualization visualization) {
+        visualization.setCreationDate(new Date());
+    }
+
+}

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/VisualizationRepository.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/VisualizationRepository.java
@@ -1,0 +1,36 @@
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.data.visualization;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.data.rest.core.annotation.RestResource;
+
+/**
+ *
+ * @author Antoine Vandecreme <antoine.vandecreme at nist.gov>
+ */
+@RepositoryRestResource
+public interface VisualizationRepository
+        extends MongoRepository<Visualization, String> {
+
+    @Override
+    @RestResource(exported = false)
+    void delete(Visualization t);
+
+    Page<Visualization> findByNameContainingIgnoreCase(
+            @Param("name") String name, Pageable p);
+
+}

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/VisualizationResourceProcessor.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/VisualizationResourceProcessor.java
@@ -1,0 +1,41 @@
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.data.visualization;
+
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.ResourceProcessor;
+
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+
+import org.springframework.stereotype.Component;
+
+/**
+ *
+ * @author Mylene Simon <mylene.simon at nist.gov>
+ */
+@Component
+public class VisualizationResourceProcessor
+        implements ResourceProcessor<Resource<Visualization>> {
+
+    @Override
+    public Resource<Visualization> process(Resource<Visualization> resource) {
+
+        Link downloadLink = linkTo(VisualizationDownloadController.class,
+                resource.getContent().getId())
+                .withRel("download");
+        resource.add(downloadLink);
+
+        return resource;
+    }
+
+}

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/LayersGroup.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/LayersGroup.java
@@ -1,0 +1,55 @@
+/*
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.data.visualization.manifest;
+
+import java.util.List;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import gov.nist.itl.ssd.wipp.backend.data.visualization.manifest.layers.Layer;
+
+/**
+ * @author Mylene Simon <mylene.simon at nist.gov>
+ *
+ */
+public class LayersGroup {
+
+	@Field("id")
+	private String id;
+	
+	private String name;
+	
+	private List<Layer> layers;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public List<Layer> getLayers() {
+		return layers;
+	}
+
+	public void setLayers(List<Layer> layers) {
+		this.layers = layers;
+	}
+}

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/Manifest.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/Manifest.java
@@ -1,0 +1,31 @@
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.data.visualization.manifest;
+
+import java.util.List;
+
+/**
+ * @author Mylene Simon <mylene.simon at nist.gov>
+ *
+ */
+public class Manifest {
+
+	private List<LayersGroup> layersGroups;
+
+	public List<LayersGroup> getLayersGroups() {
+		return layersGroups;
+	}
+
+	public void setLayersGroup(List<LayersGroup> layersGroups) {
+		this.layersGroups = layersGroups;
+	}
+}

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/AcquiredIntensity.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/AcquiredIntensity.java
@@ -1,0 +1,50 @@
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.data.visualization.manifest.layers;
+
+/**
+ * @author Mylene Simon <mylene.simon at nist.gov>
+ *
+ */
+public class AcquiredIntensity {
+	
+	private String type;
+	
+	private double min;
+	
+	private double max;
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public double getMin() {
+		return min;
+	}
+
+	public void setMin(double min) {
+		this.min = min;
+	}
+
+	public double getMax() {
+		return max;
+	}
+
+	public void setMax(double max) {
+		this.max = max;
+	}
+
+}

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/BaseUrlManualRefDeserializer.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/BaseUrlManualRefDeserializer.java
@@ -1,0 +1,24 @@
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.data.visualization.manifest.layers;
+
+import gov.nist.itl.ssd.wipp.backend.core.rest.ManualRefDeserializer;
+
+/**
+ *
+ * @author Mylene Simon <mylene.simon at nist.gov>
+ */
+public class BaseUrlManualRefDeserializer extends ManualRefDeserializer {
+
+    public BaseUrlManualRefDeserializer() {
+    }
+}

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/BaseUrlManualRefSerializer.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/BaseUrlManualRefSerializer.java
@@ -1,0 +1,64 @@
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.data.visualization.manifest.layers;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.hateoas.EntityLinks;
+import org.springframework.hateoas.Link;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.support.SpringBeanAutowiringSupport;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
+import gov.nist.itl.ssd.wipp.backend.data.pyramid.Pyramid;
+
+/**
+ * @author Mylene Simon <mylene.simon at nist.gov>
+ *
+ */
+@Component
+public class BaseUrlManualRefSerializer extends JsonSerializer<String> {
+
+	@Autowired
+    private EntityLinks entityLinks;
+	
+	@Override
+	public void serialize(String value, JsonGenerator gen, SerializerProvider sp)
+			throws IOException, JsonProcessingException {
+		if (value != null) {
+			Link link = entityLinks.linkToSingleResource(
+                    Pyramid.class,
+                    value
+            );
+			
+			if (link != null) {
+				// replace standard link by custom one for pyramids
+				String selfUri = link.getHref();
+		        String pyramidBaseUri = CoreConfig.BASE_URI + "/pyramids/"
+		                + value;
+
+		        String baseUri = selfUri.replace(pyramidBaseUri,
+		        		CoreConfig.PYRAMIDS_BASE_URI + "/"
+		                + value);
+				gen.writeString(baseUri);
+			}
+		}
+		
+	}
+
+}

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/Fetching.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/Fetching.java
@@ -1,0 +1,45 @@
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.data.visualization.manifest.layers;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * @author Mylene Simon <mylene.simon at nist.gov>
+ *
+ */
+public class Fetching {
+	
+	@JsonDeserialize(using = FetchingUrlManualRefDeserializer.class)
+	@JsonSerialize(using = FetchingUrlManualRefSerializer.class)
+	private String url;
+	
+	private boolean originalResolutionOnly;
+
+	public String getUrl() {
+		return url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+	public boolean isOriginalResolutionOnly() {
+		return originalResolutionOnly;
+	}
+
+	public void setOriginalResolutionOnly(boolean originalResolutionOnly) {
+		this.originalResolutionOnly = originalResolutionOnly;
+	}
+
+}

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/FetchingUrlManualRefDeserializer.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/FetchingUrlManualRefDeserializer.java
@@ -1,0 +1,42 @@
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.data.visualization.manifest.layers;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ *
+ * @author Mylene Simon <mylene.simon at nist.gov>
+ */
+public class FetchingUrlManualRefDeserializer extends JsonDeserializer<String> {
+
+    public FetchingUrlManualRefDeserializer() {
+    }
+
+    @Override
+    public String deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+        URI uri = ctxt.readValue(jp, URI.class);
+
+        if (uri != null) {
+	        String[] parts = uri.getPath().split("/");
+	        return parts[parts.length - 2];
+        }
+        
+        return null;
+    }
+}

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/FetchingUrlManualRefSerializer.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/FetchingUrlManualRefSerializer.java
@@ -1,0 +1,48 @@
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.data.visualization.manifest.layers;
+
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+
+import java.io.IOException;
+
+import org.springframework.hateoas.Link;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import gov.nist.itl.ssd.wipp.backend.data.pyramid.PyramidFetchingController;
+
+/**
+ * @author Mylene Simon <mylene.simon at nist.gov>
+ *
+ */
+@Component
+public class FetchingUrlManualRefSerializer extends JsonSerializer<String> {
+	
+	@Override
+	public void serialize(String value, JsonGenerator gen, SerializerProvider sp)
+			throws IOException, JsonProcessingException {
+		if (value != null) {
+			Link fetchingLink = linkTo(PyramidFetchingController.class,
+	                value)
+	                .withRel("fetching");
+			if (fetchingLink != null) {
+				gen.writeString(fetchingLink.getHref());
+			}
+		}
+		
+	}
+}

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/Layer.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/Layer.java
@@ -1,0 +1,171 @@
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.data.visualization.manifest.layers;
+
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * @author Mylene Simon <mylene.simon at nist.gov>
+ *
+ */
+public class Layer {
+	
+	@Field("id")
+	private String id;
+	
+	private String name;
+	
+	//@ManualRef(Pyramid.class)
+	@JsonDeserialize(using = BaseUrlManualRefDeserializer.class)
+	@JsonSerialize(using = BaseUrlManualRefSerializer.class)
+	private String baseUrl;
+	
+	private boolean singleFrame;
+	
+	private String framesPrefix;
+	
+	private String framesSuffix;
+	
+	private int openOnFrame;
+	
+	private int numberOfFrames;
+	
+	private int framesOffset;
+	
+	private int[] framesList;
+	
+	private int paddingSize;
+	
+	private AcquiredIntensity acquiredIntensity;
+	
+	private Scalebar scalebar;
+	
+	private Fetching fetching;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getBaseUrl() {
+		return baseUrl;
+	}
+
+	public void setBaseUrl(String baseUrl) {
+		this.baseUrl = baseUrl;
+	}
+
+	public boolean isSingleFrame() {
+		return singleFrame;
+	}
+
+	public void setSingleFrame(boolean singleFrame) {
+		this.singleFrame = singleFrame;
+	}
+
+	public String getFramesPrefix() {
+		return framesPrefix;
+	}
+
+	public void setFramesPrefix(String framesPrefix) {
+		this.framesPrefix = framesPrefix;
+	}
+
+	public String getFramesSuffix() {
+		return framesSuffix;
+	}
+
+	public void setFramesSuffix(String framesSuffix) {
+		this.framesSuffix = framesSuffix;
+	}
+
+	public int getOpenOnFrame() {
+		return openOnFrame;
+	}
+
+	public void setOpenOnFrame(int openOnFrame) {
+		this.openOnFrame = openOnFrame;
+	}
+
+	public int getNumberOfFrames() {
+		return numberOfFrames;
+	}
+
+	public void setNumberOfFrames(int numberOfFrames) {
+		this.numberOfFrames = numberOfFrames;
+	}
+
+	public int getFramesOffset() {
+		return framesOffset;
+	}
+
+	public void setFramesOffset(int framesOffset) {
+		this.framesOffset = framesOffset;
+	}
+
+	public int[] getFramesList() {
+		return framesList;
+	}
+
+	public void setFramesList(int[] framesList) {
+		this.framesList = framesList;
+	}
+
+	public int getPaddingSize() {
+		return paddingSize;
+	}
+
+	public void setPaddingSize(int paddingSize) {
+		this.paddingSize = paddingSize;
+	}
+
+	public AcquiredIntensity getAcquiredIntensity() {
+		return acquiredIntensity;
+	}
+
+	public void setAcquiredIntensity(AcquiredIntensity acquiredIntensity) {
+		this.acquiredIntensity = acquiredIntensity;
+	}
+
+	public Scalebar getScalebar() {
+		return scalebar;
+	}
+
+	public void setScalebar(Scalebar scalebar) {
+		this.scalebar = scalebar;
+	}
+
+	public Fetching getFetching() {
+		return fetching;
+	}
+
+	public void setFetching(Fetching fetching) {
+		this.fetching = fetching;
+	}
+	
+	
+
+}

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/Scalebar.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/Scalebar.java
@@ -1,0 +1,40 @@
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.data.visualization.manifest.layers;
+
+/**
+ * @author Mylene Simon <mylene.simon at nist.gov>
+ *
+ */
+public class Scalebar {
+	
+	private double pixelsPerMeter;
+	
+	private String unitType;
+
+	public double getPixelsPerMeter() {
+		return pixelsPerMeter;
+	}
+
+	public void setPixelsPerMeter(double pixelsPerMeter) {
+		this.pixelsPerMeter = pixelsPerMeter;
+	}
+
+	public String getUnitType() {
+		return unitType;
+	}
+
+	public void setUnitType(String unitType) {
+		this.unitType = unitType;
+	}
+
+}


### PR DESCRIPTION
Add pyramid visualizations management code (model, repository, controllers, handlers,...) from WIPP 2.3.

Note: Spring boot version was downgraded to 2.0.3 in `wipp-backend-application` to make it consistent with version used in `wipp-backend-core` (mismatch was causing bug in some of our custom Json serializers)

Related issue: #40 