### PR TITLE
chore: migrate Dockerfile from WIPP-deploy repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM openjdk:8-jdk-alpine
+MAINTAINER National Institute of Standards and Technology
+
+EXPOSE 8080
+
+ARG BACKEND_NAME="wipp-backend-application"
+ARG EXEC_DIR="/opt/wipp"
+ARG DATA_DIR="/data/WIPP-plugins"
+
+# Create exec and data folders
+RUN mkdir -p \
+  ${EXEC_DIR}/config \
+  ${DATA_DIR}
+
+# Copy WIPP backend application exec WAR
+COPY ${BACKEND_NAME}/target/${BACKEND_NAME}-*-exec.war ${EXEC_DIR}/wipp-backend.war
+
+# Copy properties and entrypoint script
+COPY docker/application.properties /opt/wipp/config
+COPY docker/entrypoint.sh /usr/local/bin
+
+# Set working directory
+WORKDIR "/opt/wipp"
+
+# Entrypoint
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/application.properties
+++ b/docker/application.properties
@@ -1,0 +1,46 @@
+wipp.version=3.0.0
+
+spring.data.rest.basePath=/api
+
+# MongoDB configuration
+spring.data.mongodb.host=@mongo_host@
+spring.data.mongodb.port=@mongo_port@
+spring.data.mongodb.database=wipp
+
+# Data storage root folder configuration
+storage.root=/data/WIPP-plugins
+
+# Kubernetes PVC name for WIPP Data volume
+kube.wippdata.pvc=wippdata-pvc
+
+# Workflow management configuration
+workflow.management.system=@workflow.management.system@
+workflow.binary=argo --kubeconfig /tmp/kubeconfig
+storage.workflows=/data/WIPP-plugins/workflows
+
+# Job storage configuration
+storage.temp.jobs=/data/WIPP-plugins/temp/jobs
+
+# Image storage configuration
+storage.collections=/data/WIPP-plugins/collections
+storage.collections.upload.tmp=/data/WIPP-plugins/temp/collections
+
+# Stitching storage configuration
+storage.stitching=/data/WIPP-plugins/stitching
+
+# Image OME TIFF conversion configuration
+ome.converter.threads=6
+
+# Image upload - Flow.js configurtion
+multipart.maxFileSize=3MB
+multipart.maxRequestSize=30MB
+
+# JACKSON (JacksonProperties)
+spring.jackson.mapper.ACCEPT_CASE_INSENSITIVE_ENUMS = true
+
+
+# Logging configuration
+logging.path=logs
+logging.level.org.springframework.web=INFO
+logging.level.loci.formats.in=WARN
+server.tomcat.accessLogEnabled=true

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+if [ $# -ne 2 ]
+then
+  echo "Illegal number of parameters. Exiting..."
+  echo "Command: ./entrypoint.sh \${mongo_host} \${mongo_port}"
+  exit 1
+fi
+
+MONGO_HOST=$1
+MONGO_PORT=$2
+
+sed -i \
+  -e 's/@mongo_host@/'"${MONGO_HOST}"'/' \
+  -e 's/@mongo_port@/'"${MONGO_PORT}"'/' \
+  /opt/wipp/config/application.properties
+
+exec /usr/bin/java -jar /opt/wipp/wipp-backend.war


### PR DESCRIPTION
Migrate Dockerfile + scripts and configurations files needed for Docker images from [WIPP-deploy](https://github.com/usnistgov/WIPP-deploy/tree/develop/docker/backend).

Changes from original Dockerfile:
- Backend exec WAR is copied from target folder instead of downloaded from internal Nexus

Our current Jenkins pipeline for building the backend exec WAR:
```
node(label: "maven") {
    stage("Preparation") {
        step([$class: "WsCleanup"])
        git branch: "develop",
            credentialsId: 'jenkins-ssh-git',
            url: 'ssh://git@github.com/usnistgov/WIPP-backend.git'
        sh "mvn clean validate"
    }
    stage("Install") {
        sh "mvn compile -P prod -U"
    }
    stage("Testing") {
        sh "mvn test"
    }
    stage("Deployment") {
        sh '''
            mvn deploy -P prod -DskipTests \
                -DaltDeploymentRepository=snapshots::default::$NEXUS_WEB_URL/repository/maven-local/
        '''
    }
}
```