### PR TITLE
fix: support image planes > 2GB when converting to tiled OME TIFF

### DIFF
--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/utils/tiledtiffs/TiledOmeTiffConverter.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/utils/tiledtiffs/TiledOmeTiffConverter.java
@@ -30,10 +30,11 @@ import loci.formats.services.OMEXMLService;
 import loci.formats.codec.CompressionType;
 
 /**
- * Inspired from https://docs.openmicroscopy.org/bio-formats/5.9.1/developers/tiling.html
+ * Inspired from https://docs.openmicroscopy.org/bio-formats/5.9.1/_downloads/OverlappedTiledWriter.java
  * This class reads a full image and use an OME-Tiff writer to automatically write out the image in a tiled format.
  *
  * @author Mohamed Ouladi <mohamed.ouladi at nist.gov>
+ * @author Nick Schaub <nick.schaub at nih.gov>
  */
 public class TiledOmeTiffConverter {
 


### PR DESCRIPTION
**Summary:** This PR fixes an error generated by Bioformats when converting an image with single plane larger than 2GB.

**Details:** An attempt to convert an image to ome format with single plane dimensions of 46912 x 48320 (width x height) resulted in the following error:
```
java.io.IOException: Cannot convert image to OME TIFF.
	at gov.nist.itl.ssd.wipp.backend.data.imagescollection.images.ImageUploadController.convertToTiledOmeTiff(ImageUploadController.java:188) [wipp-backend-data-3.0.0-SNAPSHOT.jar!/:na]
	at gov.nist.itl.ssd.wipp.backend.data.imagescollection.images.ImageUploadController.doSubmit(ImageUploadController.java:148) [wipp-backend-data-3.0.0-SNAPSHOT.jar!/:na]
	at gov.nist.itl.ssd.wipp.backend.data.imagescollection.images.ImageUploadController.lambda$submitImageToExtractor$0(ImageUploadController.java:138) [wipp-backend-data-3.0.0-SNAPSHOT.jar!/:na]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) ~[na:1.8.0_212]
	at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[na:1.8.0_212]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) ~[na:1.8.0_212]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) ~[na:1.8.0_212]
	at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_212]
Caused by: loci.formats.FormatException: Image plane too large. Only 2GB of data can be extracted at one time. You can work around the problem by opening the plane in tiles; for further details, see: https://docs.openmicroscopy.org/bio-formats/6.0.1/about/bug-reporting.html#common-issues-to-check
	at loci.formats.FormatReader.openBytes(FormatReader.java:878) ~[formats-api-6.0.1.jar!/:6.0.1]
	at loci.formats.FormatReader.openBytes(FormatReader.java:855) ~[formats-api-6.0.1.jar!/:6.0.1]
	at loci.formats.ImageReader.openBytes(ImageReader.java:436) ~[formats-api-6.0.1.jar!/:6.0.1]
	at gov.nist.itl.ssd.wipp.backend.data.utils.tiledtiffs.TiledOmeTiffConverter.readWriteTiles(TiledOmeTiffConverter.java:92) ~[wipp-backend-data-3.0.0-SNAPSHOT.jar!/:na]
	at gov.nist.itl.ssd.wipp.backend.data.imagescollection.images.ImageUploadController.convertToTiledOmeTiff(ImageUploadController.java:185) [wipp-backend-data-3.0.0-SNAPSHOT.jar!/:na]
	... 7 common frames omitted
Caused by: java.lang.IllegalArgumentException: Array size too large: 46912 x 48320 x 1 x 2
	at loci.common.DataTools.safeMultiply32(DataTools.java:1286) ~[ome-common-6.0.0.jar!/:6.0.0]
	at loci.common.DataTools.allocate(DataTools.java:1259) ~[ome-common-6.0.0.jar!/:6.0.0]
	at loci.formats.FormatReader.openBytes(FormatReader.java:875) ~[formats-api-6.0.1.jar!/:6.0.1]
	... 11 common frames omitted
```
The error appears to be caused by Bioformats using an `int` to index files, so when a single image plane is greater than 2^31 bytes, Bioformats throws an error.
**Solution:** The above error is resolved by loading pieces of the target file and saving, rather than loading the whole plane and saving. The tiled tiff is created by loading `tileSizeX`x`tileSizeY` pixels and saving them to the tiff, avoiding the Bioformats error.
**Note:** This PR preserves the current operation of `TiledOmeTiffConverter.java`, which only saves the first image plane. The only change is that the file is saved `tileSizeX`x`tileSizeY` pixels at a time.