### PR TITLE
WIPP PVC point to wipp folder root, do not use subpath

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,8 +24,13 @@ pipeline {
             returnStdout: true
         )}"""
         DOCKER_VERSION = readFile(file: 'deploy/docker/VERSION')
+        CEPH_NAMESPACE = "rook-ceph"
+        CEPH_SHARED_FS_NAME = "myfs"
+        CEPH_SHARED_FS_WIPP_PATH = "/wipp"
+        WIPP_PVC_NAME "wipp-pv-claim"
         SHARED_PVC_NAME = "shared-pv-claim"
         STORAGE_CLASS_NAME = "rook-ceph-block"
+        STORAGE_WIPP = "100Gi"
         STORAGE_MONGO = "10Gi"
         ELASTIC_APM_URL = "https://apm.ci.aws.labshare.org"
     }
@@ -93,10 +98,13 @@ pipeline {
             steps {
                 dir('deploy/kubernetes') {
                     script {
-                        sh "sed -i 's/SHARED_PVC_NAME_VALUE/${SHARED_PVC_NAME}/g' mongo-deployment.yaml"
-                        sh "sed -i 's/STORAGE_CLASS_NAME_VALUE/${STORAGE_CLASS_NAME}/g' mongo-deployment.yaml"
-                        sh "sed -i 's/STORAGE_MONGO_VALUE/${STORAGE_MONGO}/g' mongo-deployment.yaml"
-                        sh "sed -i 's/SHARED_PVC_NAME_VALUE/${SHARED_PVC_NAME}/g' backend-deployment.yaml"
+                        sh "sed -i 's/STORAGE_WIPP_VALUE/${STORAGE_WIPP}/g' storage-ceph.yaml"
+                        sh "sed -i 's/CEPH_NAMESPACE_VALUE/${CEPH_NAMESPACE}/g' storage-ceph.yaml"
+                        sh "sed -i 's/CEPH_SHARED_FS_NAME_VALUE/${CEPH_SHARED_FS_NAME}/g' storage-ceph.yaml"
+                        sh "sed -i 's/CEPH_SHARED_FS_WIPP_PATH_VALUE/${CEPH_SHARED_FS_WIPP_PATH}/g' storage-ceph.yaml"
+                        sh "sed -i 's/WIPP_PVC_NAME_VALUE/${WIPP_PVC_NAME}/g' storage-ceph.yaml"
+                        sh "sed -i 's/STORAGE_CLASS_NAME_VALUE/${STORAGE_CLASS_NAME}/g' storage-ceph.yaml"
+                        sh "sed -i 's/STORAGE_MONGO_VALUE/${STORAGE_MONGO}/g' storage-ceph.yaml"
                         sh "sed -i 's/BACKEND_VERSION_VALUE/${DOCKER_VERSION}/g' backend-deployment.yaml"
                         sh "sed -i 's|ELASTIC_APM_URL_VALUE|${ELASTIC_APM_URL}|g' backend-deployment.yaml"
                         sh "sed -i 's/BACKEND_HOST_NAME_VALUE/${BACKEND_HOST_NAME}/g' services.yaml"

--- a/deploy/kubernetes/backend-deployment.yaml
+++ b/deploy/kubernetes/backend-deployment.yaml
@@ -49,7 +49,7 @@ spec:
         - image: labshare/wipp-backend:BACKEND_VERSION_VALUE
           name: wipp-backend
           imagePullPolicy: Always
-          args: ["wipp-mongo", "27017", "SHARED_PVC_NAME_VALUE"]
+          args: ["wipp-mongo", "27017", "WIPP_PVC_NAME_VALUE"]
           env:
             - name: ELASTIC_APM_SERVER_URLS
               value: ELASTIC_APM_URL_VALUE
@@ -60,13 +60,12 @@ spec:
           volumeMounts:
             - mountPath: /data/WIPP-plugins
               name: data
-              subPath: wipp
           ports:
             - containerPort: 8080
       volumes:
         - name: data
           persistentVolumeClaim:
-            claimName: SHARED_PVC_NAME_VALUE
+            claimName: WIPP_PVC_NAME_VALUE
       restartPolicy: Always
       imagePullSecrets:
         - name: labshare-docker

--- a/deploy/kubernetes/mongo-deployment.yaml
+++ b/deploy/kubernetes/mongo-deployment.yaml
@@ -26,16 +26,3 @@ spec:
         persistentVolumeClaim:
           claimName: mongo-pv-claim
       restartPolicy: Always
----
-# PVC for MongoDB
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: mongo-pv-claim
-spec:
-  storageClassName: STORAGE_CLASS_NAME_VALUE
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: STORAGE_MONGO_VALUE

--- a/deploy/kubernetes/storage-ceph.yaml
+++ b/deploy/kubernetes/storage-ceph.yaml
@@ -1,0 +1,50 @@
+# PV for WIPP-backend
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  labels:
+    name: wipp-volume
+  name: wipp-pv
+spec:
+  accessModes:
+  - ReadWriteMany
+  capacity:
+    storage: STORAGE_WIPP_VALUE
+  flexVolume:
+    driver: ceph.rook.io/rook
+    fsType: ceph
+    options:
+      clusterNamespace: CEPH_NAMESPACE_VALUE
+      fsName: CEPH_SHARED_FS_NAME_VALUE
+      path: CEPH_SHARED_FS_WIPP_PATH_VALUE
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: rook-ceph-block
+---
+# PVC for WIPP-backend
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: WIPP_PVC_NAME_VALUE
+spec:
+  storageClassName: rook-ceph-block
+  accessModes:
+  - ReadWriteMany
+  selector:
+    matchLabels:
+      name: wipp-volume
+  resources:
+    requests:
+      storage: STORAGE_WIPP_VALUE
+---
+# PVC for MongoDB
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mongo-pv-claim
+spec:
+  storageClassName: STORAGE_CLASS_NAME_VALUE
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: STORAGE_MONGO_VALUE

--- a/deploy/kubernetes/storage-hostpath.yaml
+++ b/deploy/kubernetes/storage-hostpath.yaml
@@ -1,0 +1,29 @@
+# PV for WIPP-backend
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: wipp-volume
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/data/WIPP-plugins"
+---
+# PVC for WIPP-backend
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: WIPP_PVC_NAME_VALUE
+spec:
+  storageClassName: manual
+  volumeName: wipp-volume
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi


### PR DESCRIPTION
I found out that none of the workflows are working in LabShare WIPP deployment. At the same time WIPP itself is functioning correctly.

Workflows generated by WIPP are looking for PVC that point to the root of `wipp` folder (`/wipp`), but instead are given PVC that point to the root of the whole CephFS (`/`). As a result all workflows are failing (or stack in endless loop). I was able to trick it by creating symbolic links, but there needs to be a permanent fix.

To illustrate my point, look at workflow yaml generated by WIPP:
```
volumes:
  - name: "wipp-data-volume"
    persistentVolumeClaim:
      claimName: "shared-pv-claim"
```
Here `shared-pv-claim` points to the root of CephFS

```
volumeMounts:
      - mountPath: "/data/inputs"
        name: "wipp-data-volume"
        readOnly: true
      - mountPath: "/data/outputs/5d6d8841a0bc030007f4b638"
        name: "wipp-data-volume"
        readOnly: false
        subPath: "temp/jobs/5d6d8841a0bc030007f4b638"
```
So, for workflow the path `/data/inputs` is `<ceph_root> and `/data/outputs/5d6d8841a0bc030007f4b638` is `<ceph_root>/temp/jobs/5d6d8841a0bc030007f4b638`

And then passing the parameters
```
          - name: "output"
            value: "/data/outputs/5d6d8841a0bc030007f4b638/output"
          - name: "input"
            value: "/data/inputs/collections/5d54238b34b138000122e882/images"
```
So, workflow will be looking for images in `/data/inputs/collections/5d54238b34b138000122e882/images` which is `<ceph_root>/collections/5d54238b34b138000122e882/images`. In reality this path does not exist, it should be `<ceph_root>/wipp/collections/5d54238b34b138000122e882/images` instead.

WIPP backend is using subpath and avoids the issue. So, there are two paths for fixing the issue: use subpath in workflow yawl generator or enforce the requirement that WIPP PVC should point to the root of WIPP folder (do not use subpath when mounting WIPP PVC *anywhere*). After discussion with @sunnielyu we agreed that the latter is a better option.

As a result, this PR proposes:
- Stop using shared PVC for the whole CephFS
- Create WIPP PVC pointing to `/wipp` folder in CephFS
- Stop using `subpath` when mounting WIPP PVC
- Update Jenkinsfile with this new configuration
- Additionaly, I include an example of `hostPath` PVC creation as a reference (copied from WIPP-deploy)