### PR TITLE
fix: change pyramid resource handler path

### DIFF
--- a/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/CoreConfig.java
+++ b/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/CoreConfig.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 public class CoreConfig {
 
     public static final String BASE_URI = "/api";
-    public static final String PYRAMIDS_BASE_URI = "/pyramids";
+    public static final String PYRAMIDS_BASE_URI = "/pyramid-files";
     public static final int TILE_SIZE = 1024;
 
     @Value("${wipp.version}")


### PR DESCRIPTION
Changed pyramid resource handler path to avoid conflicts with pyramid views in frontend.
Related issue: https://github.com/usnistgov/WIPP-frontend/issues/46