### PR TITLE
feat: workflow submission error handling

### DIFF
--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowConverter.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowConverter.java
@@ -21,23 +21,17 @@ import gov.nist.itl.ssd.wipp.backend.core.model.data.DataHandler;
 import gov.nist.itl.ssd.wipp.backend.core.model.data.DataHandlerService;
 import gov.nist.itl.ssd.wipp.backend.core.model.job.Job;
 import gov.nist.itl.ssd.wipp.backend.core.model.workflow.Workflow;
-import gov.nist.itl.ssd.wipp.backend.core.model.workflow.WorkflowStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.mvc.ControllerLinkBuilder;
 import org.springframework.stereotype.Component;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.lang.ProcessBuilder.Redirect;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Converts workflow configuration to Argo workflow spec file (YAML) and submits workflow
+ * Converts workflow configuration to Argo workflow spec file (YAML)
  *
  * @author Philippe Dessauw <philippe.dessauw at nist.gov>
  * @author Mylene Simon <mylene.simon at nist.gov>
@@ -288,42 +282,7 @@ public class WorkflowConverter {
 
         File workflowFile = new File(workflowFilePath);
         mapper.writeValue(workflowFile, argoWorkflow);
-
-        // Launch separate submission of the argo workflow
-        List<String> builderCommands = new ArrayList<>();
-        Collections.addAll(builderCommands, coreConfig.getWorflowBinary().split(" "));
-        builderCommands.add("submit");
-        builderCommands.add("--output");
-        builderCommands.add("name");
-        builderCommands.add(workflowFilePath);
         
-        ProcessBuilder builder = new ProcessBuilder(builderCommands);
-        builder.redirectInput(Redirect.INHERIT).redirectError(Redirect.INHERIT);
-        Process process;
-        try {
-            process = builder.start();
-            int exitCode = process.waitFor();
-            
-        	InputStream is = process.getInputStream();
-        	BufferedReader reader = new BufferedReader(new InputStreamReader(is));
-            
-        	String line = reader.readLine();
-        	if(line != null){
-        		this.workflow.setGeneratedName(line);
-        	} 
-        	
-            assert exitCode == 0;
-            
-            this.workflow.setStatus(WorkflowStatus.SUBMITTED);
-        } catch (IOException ex) {
-            this.workflow.setStatus(WorkflowStatus.ERROR);
-            LOGGER.log(Level.WARNING, "Cannot start workflow ", ex);
-
-        }
-    }
-
-    public Workflow getWorkflow() {
-        return this.workflow;
     }
 
     /**

--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowSubmitController.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowSubmitController.java
@@ -7,6 +7,7 @@ import gov.nist.itl.ssd.wipp.backend.core.model.job.Job;
 import gov.nist.itl.ssd.wipp.backend.core.model.job.JobRepository;
 import gov.nist.itl.ssd.wipp.backend.core.model.workflow.Workflow;
 import gov.nist.itl.ssd.wipp.backend.core.model.workflow.WorkflowRepository;
+import gov.nist.itl.ssd.wipp.backend.core.model.workflow.WorkflowStatus;
 import gov.nist.itl.ssd.wipp.backend.core.rest.exception.ClientException;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,9 +18,15 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.ProcessBuilder.Redirect;
 import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  *
@@ -44,6 +51,8 @@ public class WorkflowSubmitController {
 
     @Autowired
     private WorkflowConverter converter;
+    
+    private static final Logger LOGGER = Logger.getLogger(WorkflowSubmitController.class.getName());
 
     @RequestMapping(
         value = "",
@@ -107,15 +116,70 @@ public class WorkflowSubmitController {
                 }
             }
 
-            converter.convert(workflow, jobsDependencies, jobsPlugins, workflowFolder + File.separator + "workflow-" + workflowId + ".yaml");
+			String workflowFilePath = workflowFolder + File.separator + "workflow-" + workflowId + ".yaml";
+			converter.convert(workflow, jobsDependencies, jobsPlugins,workflowFilePath);
+			
+			// Launch submission of the workflow to Argo
+			workflow = executeSubmissionCommand(workflow, workflowFilePath);
+            workflow.setStatus(WorkflowStatus.SUBMITTED);
 
             // Save the workflow and send the HTTP response
-            Workflow submittedWorkflow = converter.getWorkflow();
-            workflowRepository.save(submittedWorkflow);
-            return new ResponseEntity<>(submittedWorkflow, HttpStatus.OK);
-        } catch (Exception exc) {
-        	throw new ClientException("Error while submitting workflow " + exc.getMessage());
+            workflowRepository.save(workflow);
+            return new ResponseEntity<>(workflow, HttpStatus.OK);
+            
+        } catch (Exception ex) {
+        	workflow.setStatus(WorkflowStatus.ERROR);
+        	workflow.setErrorMessage(ex.getMessage());
+        	workflowRepository.save(workflow);
+            LOGGER.log(Level.SEVERE, "Cannot start workflow: " + ex.getMessage());
+        	throw new ClientException("Error while submitting workflow: " + ex.getMessage());
         }
 
+    }
+    
+    /**
+     * Execute Argo workflow submission command
+     * @param workflow
+     * @param workflowFilePath
+     * @return
+     * @throws IOException
+     * @throws InterruptedException
+     * @throws RuntimeException
+     */
+	private Workflow executeSubmissionCommand(Workflow workflow, String workflowFilePath)
+			throws IOException, InterruptedException, RuntimeException {
+        // Build Argo command
+    	List<String> builderCommands = new ArrayList<>();
+        Collections.addAll(builderCommands, config.getWorflowBinary().split(" "));
+        builderCommands.add("submit");
+        builderCommands.add("--output");
+        builderCommands.add("name");
+        builderCommands.add(workflowFilePath);
+        
+        ProcessBuilder builder = new ProcessBuilder(builderCommands);
+        builder.redirectInput(Redirect.INHERIT);
+        Process process;
+        
+        // Submit workflow to Argo
+        process = builder.start();
+        int exitCode = process.waitFor();
+    	
+        // if Argo exit code is zero, submission was successful, get generated name
+    	if (exitCode == 0) {
+    		InputStream is = process.getInputStream();
+        	BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+        	String line = reader.readLine();
+        	if(line != null){
+        		workflow.setGeneratedName(line);
+        	} 
+        // else submission failed, get error message
+    	} else {
+    		InputStream es = process.getErrorStream();
+    		BufferedReader errorReader = new BufferedReader(new InputStreamReader(es));
+    		String errorMsg = errorReader.readLine();
+    		throw new RuntimeException(errorMsg);
+    	}
+    	
+    	return workflow;
     }
 }

--- a/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/model/workflow/Workflow.java
+++ b/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/model/workflow/Workflow.java
@@ -32,18 +32,7 @@ public class Workflow {
     
     private String generatedName;
 	
-//    protected List<String> jobs = new ArrayList<>();
-    
-//    protected Map<String, Set<String>> dependencies = new HashMap<String, Set<String>>();
-	
-//    protected List<WorkflowNotification> workflowNotifications = new ArrayList<>();
-	
-//	public abstract void addJob(Job job, List<String> arguments,
-//			List<WorkflowNotification> notifications);
-	
-//	public abstract void addDependency(String child, String parent);
-	
-//	public abstract void addWorkflowNotification(WorkflowNotification notification);
+    private String errorMessage;
 
     /**
 	 * @return the id
@@ -136,46 +125,19 @@ public class Workflow {
 		this.generatedName = name;
 	}
 
-//	/**
-//	 * @return the jobs
-//	 */
-//	public List<String> getJobs() {
-//		return jobs;
-//	}
-//
-//	/**
-//	 * @param jobs the jobs to set
-//	 */
-//	public void setJobs(List<String> jobs) {
-//		this.jobs = jobs;
-//	}
+	/**
+	 * @return the errorMessage
+	 */
+	public String getErrorMessage() {
+		return errorMessage;
+	}
 
-//	/**
-//	 * @return the dependencies
-//	 */
-//	public Map<String, Set<String>> getDependencies() {
-//		return dependencies;
-//	}
-//
-//	/**
-//	 * @param dependencies the dependencies to set
-//	 */
-//	public void setDependencies(Map<String, Set<String>> dependencies) {
-//		this.dependencies = dependencies;
-//	}
-//
-//	/**
-//	 * @return the workflow notifications
-//	 */
-//	public List<WorkflowNotification> getWorkflowNotifications() {
-//		return workflowNotifications;
-//	}
-//
-//	/**
-//	 * @param workflowNotifications the workflow notifications to set
-//	 */
-//	public void setWorkflowNotifications(List<WorkflowNotification> workflowNotifications) {
-//		this.workflowNotifications = workflowNotifications;
-//	}
+	/**
+	 * @param errorMessage the errorMessage to set
+	 */
+	public void setErrorMessage(String errorMessage) {
+		this.errorMessage = errorMessage;
+	}
+
 
 }


### PR DESCRIPTION
Changes:
- `WorkflowConverter` now only handles conversion to yaml, submission to Argo happens in `WorkflowSubmitController`
- Check for exit code of Argo submit command, if command failed (or anything else such as yaml conversion), get error message, set workflow status to error and throw `ClientException` 
- Added `errorMessage` attribute to `Workflow` class

Related to https://github.com/usnistgov/WIPP-frontend/issues/78