### PR TITLE
feat: basic 3D images upload support

### DIFF
--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/utils/tiledtiffs/TiledOmeTiffConverter.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/utils/tiledtiffs/TiledOmeTiffConverter.java
@@ -20,7 +20,6 @@ import java.util.logging.Logger;
 import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
 import loci.common.services.ServiceFactory;
-import loci.common.xml.XMLTools;
 import loci.formats.FormatException;
 import loci.formats.ImageReader;
 import loci.formats.FormatTools;

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/utils/tiledtiffs/TiledOmeTiffConverter.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/utils/tiledtiffs/TiledOmeTiffConverter.java
@@ -17,10 +17,10 @@ import java.nio.file.Paths;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import gov.nist.itl.ssd.wipp.backend.data.imagescollection.images.ImageUploadController;
 import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
 import loci.common.services.ServiceFactory;
+import loci.common.xml.XMLTools;
 import loci.formats.FormatException;
 import loci.formats.ImageReader;
 import loci.formats.FormatTools;
@@ -35,6 +35,7 @@ import loci.formats.codec.CompressionType;
  *
  * @author Mohamed Ouladi <mohamed.ouladi at nist.gov>
  * @author Nick Schaub <nick.schaub at nih.gov>
+ * @author Mylene Simon <mylene.simon at nist.gov>
  */
 public class TiledOmeTiffConverter {
 
@@ -60,10 +61,14 @@ public class TiledOmeTiffConverter {
 		OMEXMLService service = factory.getInstance(OMEXMLService.class);
 		IMetadata omexml = service.createOMEXMLMetadata();
 
-		// set up the reader and associate it with the input file
+		// set up the reader 
 		reader = new ImageReader();
+		// force reader to not group in multi-file formats to treat each file individually
+	    reader.setGroupFiles(false);
+		// set metadata 
 		reader.setOriginalMetadataPopulated(true);
 		reader.setMetadataStore(omexml);
+		// set input file
 		reader.setId(inputFile);
 
 		// important to delete because OME uses RandomAccessFile
@@ -91,27 +96,33 @@ public class TiledOmeTiffConverter {
 		int tilePlaneSize = tileSizeX * tileSizeY * reader.getRGBChannelCount() * bpp;
 		byte[] buf = new byte[tilePlaneSize];
 
-		// WIPP handles 2D images only, the image series are set to 0 in our case 
-		int width = reader.getSizeX();
-		int height = reader.getSizeY();
-
-		// Determined the number of tiles to read and write
-		int nXTiles = width / tileSizeX;
-		int nYTiles = height / tileSizeY;
-		if (nXTiles * tileSizeX != width) nXTiles++;
-		if (nYTiles * tileSizeY != height) nYTiles++;
-
-		for (int y=0; y<nYTiles; y++) {
-			for (int x=0; x<nXTiles; x++) {
-				
-				int tileX = x * tileSizeX;
-				int tileY = y * tileSizeY;
-				
-				int effTileSizeX = (tileX + tileSizeX) < width ? tileSizeX : width - tileX;
-				int effTileSizeY = (tileY + tileSizeY) < height ? tileSizeY : height - tileY;
-
-				buf = reader.openBytes(0, tileX, tileY, effTileSizeX, effTileSizeY);
-				writer.saveBytes(0, buf, tileX, tileY, effTileSizeX, effTileSizeY);
+		// set the current series to 0
+		reader.setSeries(0);
+	    writer.setSeries(0);	
+	    
+	    // convert each image plane in the current series 
+		for (int image=0; image<reader.getImageCount(); image++) {
+			int width = reader.getSizeX();
+			int height = reader.getSizeY();
+	
+			// Determined the number of tiles to read and write
+			int nXTiles = width / tileSizeX;
+			int nYTiles = height / tileSizeY;
+			if (nXTiles * tileSizeX != width) nXTiles++;
+			if (nYTiles * tileSizeY != height) nYTiles++;
+	
+			for (int y=0; y<nYTiles; y++) {
+				for (int x=0; x<nXTiles; x++) {
+					
+					int tileX = x * tileSizeX;
+					int tileY = y * tileSizeY;
+					
+					int effTileSizeX = (tileX + tileSizeX) < width ? tileSizeX : width - tileX;
+					int effTileSizeY = (tileY + tileSizeY) < height ? tileSizeY : height - tileY;
+	
+					buf = reader.openBytes(image, tileX, tileY, effTileSizeX, effTileSizeY);
+					writer.saveBytes(image, buf, tileX, tileY, effTileSizeX, effTileSizeY);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Basic 3D images upload and conversion support:
- each plane in the 3D image will be converted (as opposed to only the first one)
- auto-grouping of images during conversion to tiled ome-tiff is disabled to avoid issues when uploading a set of 3D slices (multiple files that will each be treated as a 2D image for now).

## Related issues

<!-- Link related issues below. Insert the issue link or reference -->
