### PR TITLE
fix: make storageClassName configurable everywhere

### DIFF
--- a/deploy/kubernetes/storage-ceph.yaml
+++ b/deploy/kubernetes/storage-ceph.yaml
@@ -4,7 +4,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: WIPP_PVC_NAME_VALUE
 spec:
-  storageClassName: rook-cephfs
+  storageClassName: STORAGE_CLASS_NAME_VALUE
   accessModes:
   - ReadWriteMany
   resources:


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

<!-- Briefly describe what are the changes proposed in this PR, and highlight any breaking change. -->
Make storageClassName configurable in all instances of setting storage. Existing definition has `rook-cephfs` hardcoded

## Related issues

<!-- Link related issues below. Insert the issue link or reference -->
