### PR TITLE
fix: temporarily disable because of breaking changes in current version

### DIFF
--- a/wipp-backend-application/src/main/java/gov/nist/itl/ssd/wipp/backend/Application.java
+++ b/wipp-backend-application/src/main/java/gov/nist/itl/ssd/wipp/backend/Application.java
@@ -36,15 +36,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import gov.nist.itl.ssd.wipp.backend.core.model.data.DataHandlerFactory;
 import gov.nist.itl.ssd.wipp.backend.core.rest.annotation.IdExposed;
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Tag;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.data.rest.configuration.SpringDataRestConfiguration;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2WebMvc;
+//import springfox.documentation.builders.ApiInfoBuilder;
+//import springfox.documentation.builders.PathSelectors;
+//import springfox.documentation.builders.RequestHandlerSelectors;
+//import springfox.documentation.service.ApiInfo;
+//import springfox.documentation.service.Tag;
+//import springfox.documentation.spi.DocumentationType;
+//import springfox.documentation.spring.data.rest.configuration.SpringDataRestConfiguration;
+//import springfox.documentation.spring.web.plugins.Docket;
+//import springfox.documentation.swagger2.annotations.EnableSwagger2WebMvc;
 import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
 
 /**
@@ -57,8 +57,8 @@ import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
 @EnableEntityLinks
 @EnableHypermediaSupport(type = EnableHypermediaSupport.HypermediaType.HAL)
 @EnableWebMvc
-@EnableSwagger2WebMvc
-@Import({ SpringDataRestConfiguration.class })
+//@EnableSwagger2WebMvc
+//@Import({ SpringDataRestConfiguration.class })
 public class Application implements WebMvcConfigurer {
 	
 	@Autowired
@@ -116,56 +116,56 @@ public class Application implements WebMvcConfigurer {
                 addResourceLocations(
                 		pyramidsFolderFile
                         .toURI().toString());
-    	// Add Swagger UI resource handler
-    	registry.addResourceHandler("swagger-ui.html")
-    		.addResourceLocations("classpath:/META-INF/resources/");
-    	registry.addResourceHandler("/webjars/**")
-			.addResourceLocations("classpath:/META-INF/resources/webjars/");
+//    	// Add Swagger UI resource handler
+//    	registry.addResourceHandler("swagger-ui.html")
+//    		.addResourceLocations("classpath:/META-INF/resources/");
+//    	registry.addResourceHandler("/webjars/**")
+//			.addResourceLocations("classpath:/META-INF/resources/webjars/");
     }
     
-    /**
-     * Configure Swagger API documentation
-     * @return API Documentation configuration
-     */
-    @Bean
-    public Docket wippApi() {
-      return new Docket(DocumentationType.SWAGGER_2)
-          .select() 
-          .apis(RequestHandlerSelectors.any())    
-          .paths(PathSelectors.any()) 
-          .paths(PathSelectors.regex("/error.*").negate())
-          .paths(PathSelectors.regex("/api/profile").negate())
-      	  // workaround to avoid duplicate entries for plugins
-          .paths(PathSelectors.regex("/api/plugins").negate())
-          .build() 
-          // manually create tags to manage custom descriptions
-          .tags(
-              new Tag("CsvCollection Entity", "REST API for CSV Collections"),
-              new Tag("ImagesCollection Entity", "REST API for Images Collections"),
-              new Tag("Job Entity", "REST API for Jobs"),
-              new Tag("Notebook Entity", "REST API for Notebooks"),
-              new Tag("Plugin Entity", "REST API for Plugins"),
-              new Tag("Pyramid Entity", "REST API for Pyramids"),
-              new Tag("StitchingVector Entity", "REST API for Stitching Vectors"),
-              new Tag("TensorboardLogs Entity", "REST API for Tensorboard Logs"),
-              new Tag("TensorflowModel Entity", "REST API for Tensorflow Models"),
-              new Tag("Visualization Entity", "REST API for Pyramid Visualizations"),
-              new Tag("Workflow Entity", "REST API for Workflows"))
-          .apiInfo(apiEndPointsInfo())
-          .enableUrlTemplating(true);
-    }
-    
-    /**
-     * Configure Swagger API general information
-     * @return API information
-     */
-    private ApiInfo apiEndPointsInfo() {
-        return new ApiInfoBuilder().title("WIPP REST API Documentation")
-            .description("Web Image Processing Pipeline REST API")
-            .license("NIST Disclaimer")
-            .licenseUrl("https://www.nist.gov/disclaimer")
-            .version(coreConfig.getWippVersion())
-            .build();
-    }
+//    /**
+//     * Configure Swagger API documentation
+//     * @return API Documentation configuration
+//     */
+//    @Bean
+//    public Docket wippApi() {
+//      return new Docket(DocumentationType.SWAGGER_2)
+//          .select() 
+//          .apis(RequestHandlerSelectors.any())    
+//          .paths(PathSelectors.any()) 
+//          .paths(PathSelectors.regex("/error.*").negate())
+//          .paths(PathSelectors.regex("/api/profile").negate())
+//      	  // workaround to avoid duplicate entries for plugins
+//          .paths(PathSelectors.regex("/api/plugins").negate())
+//          .build() 
+//          // manually create tags to manage custom descriptions
+//          .tags(
+//              new Tag("CsvCollection Entity", "REST API for CSV Collections"),
+//              new Tag("ImagesCollection Entity", "REST API for Images Collections"),
+//              new Tag("Job Entity", "REST API for Jobs"),
+//              new Tag("Notebook Entity", "REST API for Notebooks"),
+//              new Tag("Plugin Entity", "REST API for Plugins"),
+//              new Tag("Pyramid Entity", "REST API for Pyramids"),
+//              new Tag("StitchingVector Entity", "REST API for Stitching Vectors"),
+//              new Tag("TensorboardLogs Entity", "REST API for Tensorboard Logs"),
+//              new Tag("TensorflowModel Entity", "REST API for Tensorflow Models"),
+//              new Tag("Visualization Entity", "REST API for Pyramid Visualizations"),
+//              new Tag("Workflow Entity", "REST API for Workflows"))
+//          .apiInfo(apiEndPointsInfo())
+//          .enableUrlTemplating(true);
+//    }
+//    
+//    /**
+//     * Configure Swagger API general information
+//     * @return API information
+//     */
+//    private ApiInfo apiEndPointsInfo() {
+//        return new ApiInfoBuilder().title("WIPP REST API Documentation")
+//            .description("Web Image Processing Pipeline REST API")
+//            .license("NIST Disclaimer")
+//            .licenseUrl("https://www.nist.gov/disclaimer")
+//            .version(coreConfig.getWippVersion())
+//            .build();
+//    }
 
 }

--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowExitController.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowExitController.java
@@ -24,7 +24,7 @@ import gov.nist.itl.ssd.wipp.backend.core.model.workflow.Workflow;
 import gov.nist.itl.ssd.wipp.backend.core.model.workflow.WorkflowRepository;
 import gov.nist.itl.ssd.wipp.backend.core.model.workflow.WorkflowStatus;
 import gov.nist.itl.ssd.wipp.backend.core.rest.exception.ClientException;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -44,7 +44,7 @@ import java.util.Optional;
  * @author Mylene Simon <mylene.simon at nist.gov>
  */
 @Controller
-@Api(tags="Workflow Entity")
+//@Api(tags="Workflow Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/workflows/{workflowId}/exit")
 public class WorkflowExitController {
 

--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowSubmitController.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowSubmitController.java
@@ -9,7 +9,7 @@ import gov.nist.itl.ssd.wipp.backend.core.model.workflow.Workflow;
 import gov.nist.itl.ssd.wipp.backend.core.model.workflow.WorkflowRepository;
 import gov.nist.itl.ssd.wipp.backend.core.model.workflow.WorkflowStatus;
 import gov.nist.itl.ssd.wipp.backend.core.rest.exception.ClientException;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -36,7 +36,7 @@ import java.util.logging.Logger;
  *
  */
 @Controller
-@Api(tags="Workflow Entity")
+//@Api(tags="Workflow Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/workflows/{workflowId}/submit")
 public class WorkflowSubmitController {
     @Autowired

--- a/wipp-backend-core/pom.xml
+++ b/wipp-backend-core/pom.xml
@@ -22,11 +22,11 @@
 			<id>spring-releases</id>
 			<url>https://repo.spring.io/libs-release</url>
 		</repository>
-	    <repository>
+	    <!-- <repository>
 			<id>JFrog</id>
 			<name>JFrog Snapshot Repository</name>
 			<url>http://oss.jfrog.org/artifactory/oss-snapshot-local/</url>
-		</repository>
+		</repository> -->
 	</repositories>
 
 	<pluginRepositories>
@@ -64,7 +64,7 @@
 			<artifactId>jackson-dataformat-xml</artifactId>
 		</dependency>
 		
-		<dependency>
+		<!-- <dependency>
 		    <groupId>io.springfox</groupId>
 		    <artifactId>springfox-swagger2</artifactId>
 		    <version>3.0.0-SNAPSHOT</version>
@@ -78,7 +78,7 @@
 			<groupId>io.springfox</groupId>
 			<artifactId>springfox-swagger-ui</artifactId>
 			<version>3.0.0-SNAPSHOT</version>
-		</dependency>
+		</dependency> -->
 
 	</dependencies>
 </project>

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/csvCollection/CsvCollectionDownloadController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/csvCollection/CsvCollectionDownloadController.java
@@ -31,14 +31,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 
 /**
 *
 * @author Mohamed Ouladi <mohamed.ouladi at nist.gov>
 */
 @Controller
-@Api(tags="CsvCollection Entity")
+//@Api(tags="CsvCollection Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/csvCollections/{csvCollectionId}/download")
 public class CsvCollectionDownloadController {
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/ImagesCollectionCopyController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/ImagesCollectionCopyController.java
@@ -15,7 +15,7 @@ import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
 import gov.nist.itl.ssd.wipp.backend.core.rest.exception.ClientException;
 import gov.nist.itl.ssd.wipp.backend.data.imagescollection.images.ImageHandler;
 import gov.nist.itl.ssd.wipp.backend.data.imagescollection.metadatafiles.MetadataFileHandler;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
  * @author Antoine Vandecreme
  */
 @Controller
-@Api(tags="ImagesCollection Entity")
+//@Api(tags="ImagesCollection Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/imagesCollections/{imagesCollectionId}/copy")
 public class ImagesCollectionCopyController {
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/ImagesCollectionDownloadController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/ImagesCollectionDownloadController.java
@@ -18,7 +18,7 @@ import gov.nist.itl.ssd.wipp.backend.data.imagescollection.images.ImageRepositor
 import gov.nist.itl.ssd.wipp.backend.data.imagescollection.metadatafiles.MetadataFile;
 import gov.nist.itl.ssd.wipp.backend.data.imagescollection.metadatafiles.MetadataFileHandler;
 import gov.nist.itl.ssd.wipp.backend.data.imagescollection.metadatafiles.MetadataFileRepository;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -42,7 +42,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
  * @author Antoine Vandecreme <antoine.vandecreme at nist.gov>
  */
 @Controller
-@Api(tags="ImagesCollection Entity")
+//@Api(tags="ImagesCollection Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/imagesCollections/{imagesCollectionId}/download")
 public class ImagesCollectionDownloadController {
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageController.java
@@ -17,7 +17,7 @@ import gov.nist.itl.ssd.wipp.backend.core.rest.exception.ClientException;
 import gov.nist.itl.ssd.wipp.backend.core.rest.exception.NotFoundException;
 import gov.nist.itl.ssd.wipp.backend.data.imagescollection.ImagesCollection;
 import gov.nist.itl.ssd.wipp.backend.data.imagescollection.ImagesCollectionRepository;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -56,7 +56,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Antoine Vandecreme <antoine.vandecreme at nist.gov>
  */
 @RestController
-@Api(tags="ImagesCollection Entity")
+//@Api(tags="ImagesCollection Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/imagesCollections/{imagesCollectionId}/images")
 @ExposesResourceFor(Image.class)
 public class ImageController {

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageUploadController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageUploadController.java
@@ -14,7 +14,7 @@ package gov.nist.itl.ssd.wipp.backend.data.imagescollection.images;
 import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
 import gov.nist.itl.ssd.wipp.backend.data.utils.flowjs.FlowFile;
 import gov.nist.itl.ssd.wipp.backend.data.utils.tiledtiffs.TiledOmeTiffConverter;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 import gov.nist.itl.ssd.wipp.backend.data.imagescollection.ImagesCollection;
 import gov.nist.itl.ssd.wipp.backend.data.imagescollection.ImagesCollectionRepository;
 import gov.nist.itl.ssd.wipp.backend.data.imagescollection.files.FileUploadController;
@@ -49,7 +49,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Mohamed Ouladi <mohamed.ouladi at nist.gov>
  */
 @RestController
-@Api(tags="ImagesCollection Entity")
+//@Api(tags="ImagesCollection Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/imagesCollections/{imagesCollectionId}/images")
 public class ImageUploadController extends FileUploadController {
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/metadatafiles/MetadataFileController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/metadatafiles/MetadataFileController.java
@@ -16,7 +16,7 @@ import gov.nist.itl.ssd.wipp.backend.core.rest.exception.ClientException;
 import gov.nist.itl.ssd.wipp.backend.core.rest.exception.NotFoundException;
 import gov.nist.itl.ssd.wipp.backend.data.imagescollection.ImagesCollection;
 import gov.nist.itl.ssd.wipp.backend.data.imagescollection.ImagesCollectionRepository;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -51,7 +51,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Antoine Vandecreme <antoine.vandecreme at nist.gov>
  */
 @RestController
-@Api(tags="ImagesCollection Entity")
+//@Api(tags="ImagesCollection Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/imagesCollections/{imagesCollectionId}/metadataFiles")
 @ExposesResourceFor(MetadataFile.class)
 public class MetadataFileController {

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/metadatafiles/MetadataFileUploadController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/metadatafiles/MetadataFileUploadController.java
@@ -13,7 +13,7 @@ package gov.nist.itl.ssd.wipp.backend.data.imagescollection.metadatafiles;
 
 import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
 import gov.nist.itl.ssd.wipp.backend.data.utils.flowjs.FlowFile;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 import gov.nist.itl.ssd.wipp.backend.data.imagescollection.ImagesCollectionRepository;
 import gov.nist.itl.ssd.wipp.backend.data.imagescollection.files.FileUploadController;
 
@@ -33,7 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
  * Adapted by Mohamed Ouladi <mohamed.ouladi@nist.gov>
  */
 @RestController
-@Api(tags="ImagesCollection Entity")
+//@Api(tags="ImagesCollection Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/imagesCollections/{imagesCollectionId}/metadataFiles")
 public class MetadataFileUploadController extends FileUploadController {
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/jupyternotebook/NotebookGetFileController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/jupyternotebook/NotebookGetFileController.java
@@ -28,14 +28,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 
 /**
 *
 * @author Mohamed Ouladi <mohamed.ouladi at nist.gov>
 */
 @Controller
-@Api(tags="Notebook Entity")
+//@Api(tags="Notebook Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/notebooks/{notebookId}/getFile")
 public class NotebookGetFileController {
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/jupyternotebook/NotebookImportController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/jupyternotebook/NotebookImportController.java
@@ -22,14 +22,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
 import gov.nist.itl.ssd.wipp.backend.core.rest.exception.ClientException;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 
 /**
 *
 * @author Mohamed Ouladi <mohamed.ouladi at nist.gov>
 */
 @RestController
-@Api(tags="Notebook Entity")
+//@Api(tags="Notebook Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/notebooks/import")
 public class NotebookImportController {
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/pyramid/PyramidFetchingController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/pyramid/PyramidFetchingController.java
@@ -50,7 +50,7 @@ import gov.nist.itl.ssd.wipp.backend.data.stitching.StitchingVector;
 import gov.nist.itl.ssd.wipp.backend.data.stitching.StitchingVectorRepository;
 import gov.nist.itl.ssd.wipp.backend.data.stitching.timeslices.StitchingVectorTimeSlice;
 import gov.nist.itl.ssd.wipp.backend.data.stitching.timeslices.StitchingVectorTimeSliceRepository;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 
 
 /**
@@ -59,7 +59,7 @@ import io.swagger.annotations.Api;
  * @author Antoine Vandecreme <antoine.vandecreme at nist.gov>
  */
 @Controller
-@Api(tags="Pyramid Entity")
+//@Api(tags="Pyramid Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/pyramids/{pyramidId}/fetching")
 public class PyramidFetchingController {
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/pyramid/timeslices/PyramidTimeSliceController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/pyramid/timeslices/PyramidTimeSliceController.java
@@ -15,7 +15,7 @@ package gov.nist.itl.ssd.wipp.backend.data.pyramid.timeslices;
 //import gov.nist.itl.ssd.wipp.wippcore.rest.exception.NotFoundException;
 import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
 import gov.nist.itl.ssd.wipp.backend.core.rest.exception.NotFoundException;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -49,7 +49,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Antoine Vandecreme
  */
 @RestController
-@Api(tags="Pyramid Entity")
+//@Api(tags="Pyramid Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/pyramids/{pyramidId}/timeSlices")
 @ExposesResourceFor(PyramidTimeSlice.class)
 public class PyramidTimeSliceController {

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/stitching/StitchingVectorStatisticsController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/stitching/StitchingVectorStatisticsController.java
@@ -12,7 +12,7 @@
 package gov.nist.itl.ssd.wipp.backend.data.stitching;
 
 import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -32,7 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @author Antoine Vandecreme
  */
 @RestController
-@Api(tags="StitchingVector Entity")
+//@Api(tags="StitchingVector Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/stitchingVectors/{stitchingVectorId}/statistics")
 public class StitchingVectorStatisticsController {
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/stitching/StitchingVectorUploadController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/stitching/StitchingVectorUploadController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import gov.nist.itl.ssd.wipp.backend.data.stitching.timeslices.StitchingVectorTimeSlice;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
 import gov.nist.itl.ssd.wipp.backend.core.rest.exception.ClientException;
 
@@ -33,7 +33,7 @@ import gov.nist.itl.ssd.wipp.backend.core.rest.exception.ClientException;
  * @author Antoine Vandecreme <antoine.vandecreme at nist.gov>
  */
 @RestController
-@Api(tags="StitchingVector Entity")
+//@Api(tags="StitchingVector Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/stitchingVectors/upload")
 public class StitchingVectorUploadController {
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/stitching/timeslices/StitchingVectorTimeSliceController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/stitching/timeslices/StitchingVectorTimeSliceController.java
@@ -47,7 +47,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import gov.nist.itl.ssd.wipp.backend.data.stitching.StitchingVectorRepository;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
 import gov.nist.itl.ssd.wipp.backend.core.rest.exception.NotFoundException;
 
@@ -57,7 +57,7 @@ import gov.nist.itl.ssd.wipp.backend.core.rest.exception.NotFoundException;
  * @author Antoine Vandecreme
  */
 @RestController
-@Api(tags="StitchingVector Entity")
+//@Api(tags="StitchingVector Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/stitchingVectors/{stitchingVectorId}/timeSlices")
 @ExposesResourceFor(StitchingVectorTimeSlice.class)
 public class StitchingVectorTimeSliceController {

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/tensorflowmodels/TensorflowModelDownloadController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/tensorflowmodels/TensorflowModelDownloadController.java
@@ -12,7 +12,7 @@
 package gov.nist.itl.ssd.wipp.backend.data.tensorflowmodels;
 
 import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -38,7 +38,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
  * @author Mohamed Ouladi <mohamed.ouladi at nist.gov>
  */
 @Controller
-@Api(tags="TensorflowModel Entity")
+//@Api(tags="TensorflowModel Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/tensorflowModels/{tensorflowModelId}/download")
 public class TensorflowModelDownloadController {
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/VisualizationDownloadController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/VisualizationDownloadController.java
@@ -42,7 +42,7 @@ import gov.nist.itl.ssd.wipp.backend.data.pyramid.PyramidRepository;
 import gov.nist.itl.ssd.wipp.backend.data.pyramid.timeslices.PyramidTimeSlice;
 import gov.nist.itl.ssd.wipp.backend.data.pyramid.timeslices.PyramidTimeSliceRepository;
 import gov.nist.itl.ssd.wipp.backend.data.visualization.manifest.Manifest;
-import io.swagger.annotations.Api;
+//import io.swagger.annotations.Api;
 
 /**
  * Controller for downloading visualization, returns a ZIP folder with pyramids + manifest
@@ -51,7 +51,7 @@ import io.swagger.annotations.Api;
  *
  */
 @Controller
-@Api(tags="Visualization Entity")
+//@Api(tags="Visualization Entity")
 @RequestMapping(CoreConfig.BASE_URI + "/visualizations/{visualizationId}/download")
 public class VisualizationDownloadController {
 


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Temporarily disable Swagger, as latest update to the library drop supports for Spring Boot 2.1.x (breaking change, WIPP-backend cannot build because of that).
We need some time to properly do the upgrade to Spring Boot 2.2.2.

