### PR TITLE
fix: pyramid visualization object serialization

### DIFF
--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/BaseUrlManualRefSerializer.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/BaseUrlManualRefSerializer.java
@@ -17,7 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.EntityLinks;
 import org.springframework.hateoas.Link;
 import org.springframework.stereotype.Component;
-import org.springframework.web.context.support.SpringBeanAutowiringSupport;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -34,8 +33,14 @@ import gov.nist.itl.ssd.wipp.backend.data.pyramid.Pyramid;
 @Component
 public class BaseUrlManualRefSerializer extends JsonSerializer<String> {
 
+	private static EntityLinks entityLinks;
+	
+	public BaseUrlManualRefSerializer() {}
+	
 	@Autowired
-    private EntityLinks entityLinks;
+    public BaseUrlManualRefSerializer(EntityLinks entityLinks) {
+        BaseUrlManualRefSerializer.entityLinks = entityLinks;
+    }
 	
 	@Override
 	public void serialize(String value, JsonGenerator gen, SerializerProvider sp)


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Fixes serialization issues for Pyramid Visualization objects (serialization was throwing `NullPointerExceptions`).
`EntityLinks` was not properly autowired as the serializers are instantiated by Jackson instead of Spring. Getting the autowired `EntityLinks` in constructor fixes the issue.


