### PR TITLE
feat: pass nodeSelector and tolerations to Argo Workflows

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -15,6 +15,8 @@ sed -i.bak \
     -e "s/BACKEND_VERSION_VALUE/${DOCKER_VERSION}/g" \
     -e "s/WIPP_PVC_NAME_VALUE/${WIPP_PVC_NAME}/g" \
     -e "s|ELASTIC_APM_URL_VALUE|${ELASTIC_APM_URL}|g" \
+    -e "s|NODE_SELECTOR_VALUE|${NODE_SELECTOR}|g" \
+    -e "s|TOLERATIONS_VALUE|${TOLERATIONS}|g" \
     deploy/kubernetes/backend-deployment.yaml
 rm deploy/kubernetes/backend-deployment.yaml.bak
 

--- a/deploy/docker/application.properties
+++ b/deploy/docker/application.properties
@@ -15,6 +15,8 @@ kube.wippdata.pvc=@shared_pvc@
 workflow.management.system=@workflow.management.system@
 workflow.binary=argo
 storage.workflows=/data/WIPP-plugins/workflows
+workflow.nodeSelector=@workflow_nodeSelector@
+workflow.tolerations=@workflow_tolerations@
 
 # Job storage configuration
 storage.temp.jobs=/data/WIPP-plugins/temp/jobs

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -1,19 +1,20 @@
 #!/bin/sh
-if [ $# -ne 3 ]
+if [ $# -ne 2 ]
 then
   echo "Illegal number of parameters. Exiting..."
-  echo "Command: ./entrypoint.sh \${mongo_host} \${mongo_port} \${shared_pvc}"
+  echo "Command: ./entrypoint.sh \${mongo_host} \${mongo_port}"
   exit 1
 fi
 
 MONGO_HOST=$1
 MONGO_PORT=$2
-SHARED_PVC=$3
 
 sed -i \
   -e 's/@mongo_host@/'"${MONGO_HOST}"'/' \
   -e 's/@mongo_port@/'"${MONGO_PORT}"'/' \
   -e 's/@shared_pvc@/'"${SHARED_PVC}"'/' \
+  -e 's|@workflow_nodeSelector@|'"${NODE_SELECTOR}"'|' \
+  -e 's|@workflow_tolerations@|'"${TOLERATIONS}"'|' \
   /opt/wipp/config/application.properties
 
 if [[ -n ${ELASTIC_APM_SERVER_URLS} && -n ${ELASTIC_APM_SERVICE_NAME} ]]; then

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
-if [ $# -ne 2 ]
+if [ $# -ne 3 ]
 then
   echo "Illegal number of parameters. Exiting..."
-  echo "Command: ./entrypoint.sh \${mongo_host} \${mongo_port}"
+  echo "Command: ./entrypoint.sh \${mongo_host} \${mongo_port} \${shared_pvc}"
   exit 1
 fi
 
 MONGO_HOST=$1
 MONGO_PORT=$2
+SHARED_PVC=$3
 
 sed -i \
   -e 's/@mongo_host@/'"${MONGO_HOST}"'/' \

--- a/deploy/kubernetes/backend-deployment.yaml
+++ b/deploy/kubernetes/backend-deployment.yaml
@@ -49,7 +49,7 @@ spec:
         - image: labshare/wipp-backend:BACKEND_VERSION_VALUE
           name: wipp-backend
           imagePullPolicy: Always
-          args: ["wipp-mongo", "27017" "WIPP_PVC_NAME_VALUE"]
+          args: ["wipp-mongo", "27017", "WIPP_PVC_NAME_VALUE"]
           env:
             - name: ELASTIC_APM_SERVER_URLS
               value: ELASTIC_APM_URL_VALUE

--- a/deploy/kubernetes/backend-deployment.yaml
+++ b/deploy/kubernetes/backend-deployment.yaml
@@ -49,7 +49,7 @@ spec:
         - image: labshare/wipp-backend:BACKEND_VERSION_VALUE
           name: wipp-backend
           imagePullPolicy: Always
-          args: ["wipp-mongo", "27017"]
+          args: ["wipp-mongo", "27017" "WIPP_PVC_NAME_VALUE"]
           env:
             - name: ELASTIC_APM_SERVER_URLS
               value: ELASTIC_APM_URL_VALUE
@@ -57,8 +57,6 @@ spec:
               value: wipp-backend
             - name: ELASTIC_APM_APPLICATION_PACKAGES
               value: gov.nist.itl.ssd.wipp.backend
-            - name: SHARED_PVC
-              value: WIPP_PVC_NAME_VALUE
             - name: NODE_SELECTOR
               value: NODE_SELECTOR_VALUE
             - name: TOLERATIONS

--- a/deploy/kubernetes/backend-deployment.yaml
+++ b/deploy/kubernetes/backend-deployment.yaml
@@ -49,7 +49,7 @@ spec:
         - image: labshare/wipp-backend:BACKEND_VERSION_VALUE
           name: wipp-backend
           imagePullPolicy: Always
-          args: ["wipp-mongo", "27017", "WIPP_PVC_NAME_VALUE"]
+          args: ["wipp-mongo", "27017"]
           env:
             - name: ELASTIC_APM_SERVER_URLS
               value: ELASTIC_APM_URL_VALUE
@@ -57,6 +57,12 @@ spec:
               value: wipp-backend
             - name: ELASTIC_APM_APPLICATION_PACKAGES
               value: gov.nist.itl.ssd.wipp.backend
+            - name: SHARED_PVC
+              value: WIPP_PVC_NAME_VALUE
+            - name: NODE_SELECTOR
+              value: NODE_SELECTOR_VALUE
+            - name: TOLERATIONS
+              value: TOLERATIONS_VALUE
           volumeMounts:
             - mountPath: /data/WIPP-plugins
               name: data
@@ -67,5 +73,3 @@ spec:
           persistentVolumeClaim:
             claimName: WIPP_PVC_NAME_VALUE
       restartPolicy: Always
-      imagePullSecrets:
-        - name: labshare-docker

--- a/sample-env
+++ b/sample-env
@@ -5,6 +5,8 @@ STORAGE_CLASS_NAME=<storage class name>
 STORAGE_MONGO=<pvc storage size>
 
 ELASTIC_APM_URL=<url to Elastic APM>
+NODE_SELECTOR=<node selector in the format "key1:value1;key2:value2;">
+TOLERATIONS=<pod tolerations in the format "key1:operator1:value1:effect1;", optional values can be skipped "key1:operator1::;">
 
 BACKEND_HOST_NAME=<host name>
 MONGO_HOST_NAME=<host name>

--- a/wipp-backend-application/src/main/resources/application.properties
+++ b/wipp-backend-application/src/main/resources/application.properties
@@ -14,6 +14,8 @@ storage.root=@storage.root@
 workflow.management.system=@workflow.management.system@
 workflow.binary=@workflow.binary@
 storage.workflows=@storage.workflows@
+workflow.nodeSelector=@workflow.nodeSelector@
+workflow.tolerations=@workflow.tolerations@
 
 # Kubernetes PVC name for WIPP Data volume
 kube.wippdata.pvc=@kube.wippdata.pvc@

--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/spec/ArgoWorkflowSpec.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/spec/ArgoWorkflowSpec.java
@@ -1,6 +1,7 @@
 package gov.nist.itl.ssd.wipp.backend.argo.workflows.spec;
 
 import java.util.List;
+import java.util.Map;
 
 /**
 *
@@ -11,6 +12,8 @@ import java.util.List;
 public class ArgoWorkflowSpec {
     private final String entrypoint = "workflow";
     private final String onExit = "exit-handler";
+    private Map<String, String> nodeSelector;
+    private List<Map<String, String>> tolerations;
     private List<ArgoAbstractTemplate> templates;
     private List<ArgoVolume> volumes;
 
@@ -22,7 +25,23 @@ public class ArgoWorkflowSpec {
 		return onExit;
 	}
 
-	public List<ArgoAbstractTemplate> getTemplates() {
+    public Map<String, String> getNodeSelector() {
+        return nodeSelector;
+    }
+
+    public void setNodeSelector(Map<String, String> node) {
+        this.nodeSelector = node;
+    }
+
+    public List<Map<String, String>> getTolerations() {
+        return tolerations;
+    }
+
+    public void setTolerations(List<Map<String, String>> tolerations) {
+        this.tolerations = tolerations;
+    }
+
+    public List<ArgoAbstractTemplate> getTemplates() {
         return templates;
     }
 

--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowSubmitController.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowSubmitController.java
@@ -152,7 +152,7 @@ public class WorkflowSubmitController {
 			throws IOException, InterruptedException, RuntimeException {
         // Build Argo command
     	List<String> builderCommands = new ArrayList<>();
-        Collections.addAll(builderCommands, config.getWorflowBinary().split(" "));
+        Collections.addAll(builderCommands, config.getWorkflowBinary().split(" "));
         builderCommands.add("submit");
         builderCommands.add("--output");
         builderCommands.add("name");

--- a/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/CoreConfig.java
+++ b/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/CoreConfig.java
@@ -42,7 +42,13 @@ public class CoreConfig {
     private String workflowsFolder;
 
     @Value("${workflow.binary}")
-    private String worflowBinary;
+    private String workflowBinary;
+
+    @Value("${workflow.nodeSelector}")
+    private String workflowNodeSelector;
+
+    @Value("${workflow.tolerations}")
+    private String workflowTolerations;
     
     @Value("${kube.wippdata.pvc}")
     private String wippDataPVCName;
@@ -146,8 +152,16 @@ public class CoreConfig {
 		return notebooksTmpFolder;
 	}
 
-	public String getWorflowBinary() {
-	    return worflowBinary;
+    public String getWorkflowBinary() {
+        return workflowBinary;
+    }
+
+    public String getWorkflowNodeSelector() {
+        return workflowNodeSelector;
+    }
+
+    public String getWorkflowTolerations() {
+        return workflowTolerations;
     }
 
 	public String getWippDataPVCName() {


### PR DESCRIPTION
## What does this PR do?

Add environment parameters in the WIPP-backend deployment that allow the user to configure nodeSelector and tolerations to Argo Workflows. This will allow users to dictate the specific set of nodes/nodegroups that all jobs in the workflows will run on in a heterogeneous Kubernetes cluster. A specific use case example for the architecture is as follows: a user wants to run WIPP plugins specifically on GPU-enabled nodes, but not all nodes in the Kubernetes cluster are GPU-enabled. Using node taints, the user can configure all the GPU-enabled nodes to prevent web server pods (ie. WIPP-backend, WIPP-frontend) from deploying in the GPU-enabled nodes. The user can then set tolerations in the Argo Workflow, that will allow Argo jobs to run on the GPU-enabled nodes. In order for Argo to not run on non-GPU-enabled nodes, the user uses the nodeSelector to dictate which specific nodes Argo can use. 

NodeSelector labels can be set using the environment variable NODE_SELECTOR and has the format "key1:value1;key2:value2" for as many node tags necessary. Pod tolerations can be set using the environment variable TOLERATIONS and has the format "key1:operator1:value1:effect1;" for as many tolerations as necessary. Optional values can be skipped, "key1:operator1::". Operator field has two options, "Equal" and "Exists", effect field has three options, "NoSchedule", "PreferNoSchedule", and "NoExecute". Node tags and taints must be configured separately in the Kubernetes cluster. Both environment variables can be left empty if no nodeSelector or tolerations are required. 

More information can be seen here:
[Taint and Tolerations](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
[Node Selector](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)

## Related issues

#109 