### PR TITLE
feat: upgrade to Spring Boot 2.2.9

### DIFF
--- a/deploy/docker/application.properties
+++ b/deploy/docker/application.properties
@@ -39,10 +39,10 @@ spring.servlet.multipart.maxRequestSize=30MB
 spring.jackson.mapper.ACCEPT_CASE_INSENSITIVE_ENUMS = true
 
 # Logging configuration
-logging.path=logs
+logging.file.path=logs
 logging.level.org.springframework.web=INFO
 logging.level.loci.formats.in=WARN
 server.tomcat.accessLogEnabled=true
 
 # Server configuration
-server.use-forward-headers=true
+server.forward-headers-strategy=framework

--- a/wipp-backend-application/pom.xml
+++ b/wipp-backend-application/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.7.RELEASE</version>
+		<version>2.2.9.RELEASE</version>
 		<relativePath />
 	</parent>
 

--- a/wipp-backend-application/src/main/java/gov/nist/itl/ssd/wipp/backend/Application.java
+++ b/wipp-backend-application/src/main/java/gov/nist/itl/ssd/wipp/backend/Application.java
@@ -28,7 +28,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
-import org.springframework.hateoas.config.EnableEntityLinks;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -54,7 +53,6 @@ import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
 @Configuration
 @ComponentScan(basePackages = {"gov.nist.itl.ssd.wipp.backend"})
 @EnableAutoConfiguration
-@EnableEntityLinks
 @EnableHypermediaSupport(type = EnableHypermediaSupport.HypermediaType.HAL)
 @EnableWebMvc
 //@EnableSwagger2WebMvc

--- a/wipp-backend-application/src/main/java/gov/nist/itl/ssd/wipp/backend/app/RootResourceProcessor.java
+++ b/wipp-backend-application/src/main/java/gov/nist/itl/ssd/wipp/backend/app/RootResourceProcessor.java
@@ -26,9 +26,9 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.data.rest.webmvc.RepositoryLinksResource;
-import org.springframework.hateoas.EntityLinks;
+import org.springframework.hateoas.server.EntityLinks;
 import org.springframework.hateoas.Link;
-import org.springframework.hateoas.ResourceProcessor;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.stereotype.Component;
 
 /**
@@ -37,7 +37,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class RootResourceProcessor
-        implements ResourceProcessor<RepositoryLinksResource> {
+        implements RepresentationModelProcessor<RepositoryLinksResource> {
 
     @Autowired
     private EntityLinks entityLinks;

--- a/wipp-backend-application/src/main/resources/application.properties
+++ b/wipp-backend-application/src/main/resources/application.properties
@@ -6,6 +6,7 @@ spring.data.rest.basePath=/api
 spring.data.mongodb.host=@mongodb.host@
 spring.data.mongodb.port=27017
 spring.data.mongodb.database=@mongodb.database@
+spring.data.mongodb.auto-index-creation=true
 
 # Data storage root folder configuration
 storage.root=@storage.root@
@@ -64,7 +65,7 @@ spring.servlet.multipart.maxRequestSize=30MB
 spring.jackson.mapper.ACCEPT_CASE_INSENSITIVE_ENUMS = true
 
 # Logging configuration
-logging.path=logs
+logging.file.path=logs
 logging.level.org.springframework.web=INFO
 logging.level.loci.formats.in=WARN
 server.tomcat.accessLogEnabled=true

--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowConverter.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowConverter.java
@@ -22,7 +22,7 @@ import gov.nist.itl.ssd.wipp.backend.core.model.data.DataHandlerService;
 import gov.nist.itl.ssd.wipp.backend.core.model.job.Job;
 import gov.nist.itl.ssd.wipp.backend.core.model.workflow.Workflow;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.hateoas.mvc.ControllerLinkBuilder;
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
@@ -207,7 +207,7 @@ public class WorkflowConverter {
 
         container.setImage("byrnedo/alpine-curl:latest");
 
-        String url = ControllerLinkBuilder.linkTo(
+        String url = WebMvcLinkBuilder.linkTo(
                 WorkflowExitController.class, workflow.getId())
                 .withRel("exit").getHref();
         LOGGER.log(Level.INFO, "workflow url: " + url);

--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowResourceProcessor.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowResourceProcessor.java
@@ -2,9 +2,9 @@ package gov.nist.itl.ssd.wipp.backend.argo.workflows.workflow;
 
 import gov.nist.itl.ssd.wipp.backend.core.model.workflow.Workflow;
 import org.springframework.hateoas.Link;
-import org.springframework.hateoas.Resource;
-import org.springframework.hateoas.ResourceProcessor;
-import org.springframework.hateoas.mvc.ControllerLinkBuilder;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.stereotype.Component;
 
 /**
@@ -14,18 +14,18 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class WorkflowResourceProcessor
-    implements ResourceProcessor<Resource<Workflow>> {
+    implements RepresentationModelProcessor<EntityModel<Workflow>> {
 
     @Override
-    public Resource<Workflow> process(Resource<Workflow> resource) {
+    public EntityModel<Workflow> process(EntityModel<Workflow> resource) {
         Workflow workflow = resource.getContent();
 
-        Link submitLink = ControllerLinkBuilder.linkTo(
+        Link submitLink = WebMvcLinkBuilder.linkTo(
             WorkflowSubmitController.class, workflow.getId())
             .withRel("submit");
         resource.add(submitLink);
 
-        Link exitLink = ControllerLinkBuilder.linkTo(
+        Link exitLink = WebMvcLinkBuilder.linkTo(
                 WorkflowExitController.class, workflow.getId())
                 .withRel("exit");
             resource.add(exitLink);

--- a/wipp-backend-core/pom.xml
+++ b/wipp-backend-core/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.7.RELEASE</version>
+		<version>2.2.9.RELEASE</version>
 		<relativePath />
 	</parent>
 	<groupId>gov.nist.itl.ssd.wipp</groupId>

--- a/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/rest/CustomResourceSupport.java
+++ b/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/rest/CustomResourceSupport.java
@@ -16,7 +16,7 @@ import java.util.List;
 import org.springframework.data.annotation.AccessType;
 import org.springframework.data.annotation.AccessType.Type;
 import org.springframework.hateoas.Link;
-import org.springframework.hateoas.ResourceSupport;
+import org.springframework.hateoas.RepresentationModel;
 
 /**
  * Workaround for https://jira.spring.io/browse/DATAREST-1363
@@ -24,11 +24,11 @@ import org.springframework.hateoas.ResourceSupport;
  * @author Mylene Simon <mylene.simon at nist.gov>
  *
  */
-public abstract class CustomResourceSupport extends ResourceSupport {
+public abstract class CustomResourceSupport extends RepresentationModel {
 
     @AccessType(Type.PROPERTY)
     public void setLinks(List<Link> links) {
-        List<Link> actual = super.getLinks();
+        List<Link> actual = super.getLinks().toList();
         actual.clear();
         actual.addAll(links);
     }

--- a/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/rest/ManualListRefResourceProcessor.java
+++ b/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/rest/ManualListRefResourceProcessor.java
@@ -11,20 +11,13 @@
  */
 package gov.nist.itl.ssd.wipp.backend.core.rest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.nist.itl.ssd.wipp.backend.core.rest.annotation.ManualListRef;
-import gov.nist.itl.ssd.wipp.backend.core.rest.annotation.ManualRef;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.hateoas.*;
-import org.springframework.hateoas.config.EnableHypermediaSupport;
-import org.springframework.hateoas.hal.HalConfiguration;
+import org.springframework.hateoas.server.EntityLinks;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.stereotype.Component;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
-
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
@@ -37,7 +30,7 @@ import java.util.stream.Stream;
  */
 @Component
 public class ManualListRefResourceProcessor
-        implements ResourceProcessor<Resource<?>> {
+        implements RepresentationModelProcessor<EntityModel<?>> {
 
     @Autowired
     private EntityLinks entityLinks;
@@ -46,7 +39,7 @@ public class ManualListRefResourceProcessor
             ManualListRefResourceProcessor.class.getName());
 
     @Override
-    public Resource<?> process(Resource<?> resource) {
+    public EntityModel<?> process(EntityModel<?> resource) {
         Class clazz = resource.getContent().getClass();
         Stream<Field> ownFields = Arrays.stream(clazz.getDeclaredFields());
 
@@ -67,7 +60,7 @@ public class ManualListRefResourceProcessor
                     Object fieldValues = field.get(resource.getContent());
                     if (fieldValues != null) {
                         for(Object fieldValue: (List<?>) fieldValues) {
-                            Link link = entityLinks.linkToSingleResource(
+                            Link link = entityLinks.linkToItemResource(
                                 manualListRef.value(),
                                 fieldValue
                             );

--- a/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/rest/ManualRefResourceProcessor.java
+++ b/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/rest/ManualRefResourceProcessor.java
@@ -19,10 +19,10 @@ import java.util.stream.Stream;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.AnnotationUtils;
-import org.springframework.hateoas.EntityLinks;
+import org.springframework.hateoas.server.EntityLinks;
 import org.springframework.hateoas.Link;
-import org.springframework.hateoas.Resource;
-import org.springframework.hateoas.ResourceProcessor;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.stereotype.Component;
 
 import gov.nist.itl.ssd.wipp.backend.core.rest.annotation.ManualRef;
@@ -33,7 +33,7 @@ import gov.nist.itl.ssd.wipp.backend.core.rest.annotation.ManualRef;
  */
 @Component
 public class ManualRefResourceProcessor
-        implements ResourceProcessor<Resource<?>> {
+        implements RepresentationModelProcessor<EntityModel<?>> {
 
     @Autowired
     private EntityLinks entityLinks;
@@ -42,7 +42,7 @@ public class ManualRefResourceProcessor
             ManualRefResourceProcessor.class.getName());
 
     @Override
-    public Resource<?> process(Resource<?> resource) {
+    public EntityModel<?> process(EntityModel<?> resource) {
 
         Class clazz = resource.getContent().getClass();
         Stream<Field> ownFields = Arrays.stream(clazz.getDeclaredFields());
@@ -62,7 +62,7 @@ public class ManualRefResourceProcessor
                     field.setAccessible(true);
                     Object fieldValue = field.get(resource.getContent());
                     if (fieldValue != null) {
-                        Link link = entityLinks.linkToSingleResource(
+                        Link link = entityLinks.linkToItemResource(
                                 manualRef.value(),
                                 fieldValue
                         );

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/csvCollection/CsvCollectionResourceProcessor.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/csvCollection/CsvCollectionResourceProcessor.java
@@ -11,14 +11,14 @@
  */
 package gov.nist.itl.ssd.wipp.backend.data.csvCollection;
 
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 import gov.nist.itl.ssd.wipp.backend.core.rest.PaginationParameterTemplatesHelper;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.hateoas.EntityLinks;
+import org.springframework.hateoas.server.EntityLinks;
 import org.springframework.hateoas.Link;
-import org.springframework.hateoas.Resource;
-import org.springframework.hateoas.ResourceProcessor;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.stereotype.Component;
 
 /**
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
 * @author Mohamed Ouladi <mohamed.ouladi at nist.gov>
 */
 @Component
-public class CsvCollectionResourceProcessor implements ResourceProcessor<Resource<CsvCollection>>{
+public class CsvCollectionResourceProcessor implements RepresentationModelProcessor<EntityModel<CsvCollection>>{
 
 	@Autowired
 	private PaginationParameterTemplatesHelper assembler;
@@ -35,7 +35,7 @@ public class CsvCollectionResourceProcessor implements ResourceProcessor<Resourc
 	private EntityLinks entityLinks;
 
 	@Override
-	public Resource<CsvCollection> process(Resource<CsvCollection> resource) {
+	public EntityModel<CsvCollection> process(EntityModel<CsvCollection> resource) {
 		CsvCollection csvCollection = resource.getContent();
 		
         Link downloadLink = linkTo(CsvCollectionDownloadController.class,
@@ -43,7 +43,7 @@ public class CsvCollectionResourceProcessor implements ResourceProcessor<Resourc
                 .withRel("download");
         resource.add(downloadLink);
 
-		Link csvFilesLink = entityLinks.linkForSingleResource(
+		Link csvFilesLink = entityLinks.linkForItemResource(
 				CsvCollection.class, csvCollection.getId())
 				.slash("csv")
 				.withRel("csv");

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/csvCollection/csv/CsvController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/csvCollection/csv/CsvController.java
@@ -25,6 +25,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.*;
+import org.springframework.hateoas.server.EntityLinks;
+import org.springframework.hateoas.server.ExposesResourceFor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -58,14 +60,14 @@ public class CsvController {
     private CsvHandler csvHandler;
 
     @RequestMapping(value = "", method = RequestMethod.GET)
-    public HttpEntity<PagedResources<Resource<Csv>>> getFilesPage(
+    public HttpEntity<PagedModel<EntityModel<Csv>>> getFilesPage(
             @PathVariable("csvCollectionId") String csvCollectionId,
             @PageableDefault Pageable pageable,
             PagedResourcesAssembler<Csv> assembler) {
         Page<Csv> files = csvRepository.findByCsvCollection(
                 csvCollectionId, pageable);
-        PagedResources<Resource<Csv>> resources
-                = assembler.toResource(files);
+        PagedModel<EntityModel<Csv>> resources
+                = assembler.toModel(files);
         resources.forEach(
                 resource -> processResource(csvCollectionId, resource));
         return new ResponseEntity<>(resources, HttpStatus.OK);
@@ -101,9 +103,9 @@ public class CsvController {
     }
 
     protected void processResource(String csvCollectionId,
-                                   Resource<Csv> resource) {
+                                   EntityModel<Csv> resource) {
         Csv file = resource.getContent();
-        Link link = entityLinks.linkForSingleResource(
+        Link link = entityLinks.linkForItemResource(
                 CsvCollection.class, csvCollectionId)
                 .slash("csv")
                 .slash(file.getFileName())

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/ImagesCollectionResourceProcessor.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/ImagesCollectionResourceProcessor.java
@@ -14,12 +14,12 @@ package gov.nist.itl.ssd.wipp.backend.data.imagescollection;
 import gov.nist.itl.ssd.wipp.backend.core.rest.PaginationParameterTemplatesHelper;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.hateoas.EntityLinks;
+import org.springframework.hateoas.server.EntityLinks;
 import org.springframework.hateoas.Link;
-import org.springframework.hateoas.Resource;
-import org.springframework.hateoas.ResourceProcessor;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
 
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.*;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
 
 import org.springframework.stereotype.Component;
 
@@ -30,7 +30,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class ImagesCollectionResourceProcessor
-        implements ResourceProcessor<Resource<ImagesCollection>> {
+        implements RepresentationModelProcessor<EntityModel<ImagesCollection>> {
 
     @Autowired
     private PaginationParameterTemplatesHelper assembler;
@@ -39,17 +39,17 @@ public class ImagesCollectionResourceProcessor
     private EntityLinks entityLinks;
 
     @Override
-    public Resource<ImagesCollection> process(
-            Resource<ImagesCollection> resource) {
+    public EntityModel<ImagesCollection> process(
+            EntityModel<ImagesCollection> resource) {
         ImagesCollection imagesCollection = resource.getContent();
 
-        Link imagesLink = entityLinks.linkForSingleResource(
+        Link imagesLink = entityLinks.linkForItemResource(
                 ImagesCollection.class, imagesCollection.getId())
                 .slash("images")
                 .withRel("images");
         resource.add(assembler.appendPaginationParameterTemplates(imagesLink));
 
-        Link metadataFileLink = entityLinks.linkForSingleResource(
+        Link metadataFileLink = entityLinks.linkForItemResource(
                 ImagesCollection.class, imagesCollection.getId())
                 .slash("metadataFiles")
                 .withRel("metadataFiles");

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageController.java
@@ -34,11 +34,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedResourcesAssembler;
-import org.springframework.hateoas.EntityLinks;
-import org.springframework.hateoas.ExposesResourceFor;
+import org.springframework.hateoas.server.EntityLinks;
+import org.springframework.hateoas.server.ExposesResourceFor;
 import org.springframework.hateoas.Link;
-import org.springframework.hateoas.PagedResources;
-import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.TemplateVariable;
 import org.springframework.hateoas.TemplateVariables;
 import org.springframework.hateoas.UriTemplate;
@@ -77,13 +77,13 @@ public class ImageController {
     private PaginationParameterTemplatesHelper paginationParameterTemplatesHelper;
 
     @RequestMapping(value = "", method = RequestMethod.GET)
-    public HttpEntity<PagedResources<Resource<Image>>> getFilesPage(
+    public HttpEntity<PagedModel<EntityModel<Image>>> getFilesPage(
             @PathVariable("imagesCollectionId") String imagesCollectionId,
             @PageableDefault Pageable pageable,
             PagedResourcesAssembler<Image> assembler) {
         Page<Image> files = imageRepository.findByImagesCollection(
                 imagesCollectionId, pageable);
-        PagedResources<Resource<Image>> resources = assembler.toResource(files);
+        PagedModel<EntityModel<Image>> resources = assembler.toModel(files);
 
         resources.forEach(
                 resource -> processResource(imagesCollectionId, resource));
@@ -163,31 +163,31 @@ public class ImageController {
     }
 
     @RequestMapping(value = "filterByFileNameRegex", method = RequestMethod.GET)
-    public HttpEntity<PagedResources<Resource<Image>>> getFilesMatchingRegexPage(
+    public HttpEntity<PagedModel<EntityModel<Image>>> getFilesMatchingRegexPage(
             @PathVariable("imagesCollectionId") String imagesCollectionId,
             @RequestParam(value="regex") String regex,
             @PageableDefault Pageable pageable,
             PagedResourcesAssembler<Image> assembler) {
         Page<Image> files = imageRepository.findByImagesCollectionAndFileNameRegex(
                 imagesCollectionId, regex, pageable);
-        PagedResources<Resource<Image>> resources = assembler.toResource(files);
+        PagedModel<EntityModel<Image>> resources = assembler.toModel(files);
         resources.forEach(
                 resource -> processResource(imagesCollectionId, resource));
         return new ResponseEntity<>(resources, HttpStatus.OK);
     }
 
     protected void processResource(String imagesCollectionId,
-            Resource<Image> resource) {
+            EntityModel<Image> resource) {
         Image file = resource.getContent();
 
-        Link link = entityLinks.linkForSingleResource(
+        Link link = entityLinks.linkForItemResource(
                 ImagesCollection.class, imagesCollectionId)
                 .slash("images")
                 .slash(file.getFileName())
                 .withSelfRel();
         resource.add(link);
 
-        link = entityLinks.linkForSingleResource(
+        link = entityLinks.linkForItemResource(
                 ImagesCollection.class, imagesCollectionId)
                 .slash("images")
                 .slash(file.getFileName())
@@ -198,10 +198,10 @@ public class ImageController {
     }
 
     protected void processCollectionResource(String imagesCollectionId,
-    		PagedResources<Resource<Image>> resources,
+    		PagedModel<EntityModel<Image>> resources,
             PagedResourcesAssembler<Image> assembler) {
 
-    	Link imagesFilterLink = entityLinks.linkForSingleResource(
+    	Link imagesFilterLink = entityLinks.linkForItemResource(
                 ImagesCollection.class, imagesCollectionId)
                 .slash("images")
                 .slash("filterByFileNameRegex")

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/metadatafiles/MetadataFileController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/metadatafiles/MetadataFileController.java
@@ -33,11 +33,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedResourcesAssembler;
-import org.springframework.hateoas.EntityLinks;
-import org.springframework.hateoas.ExposesResourceFor;
+import org.springframework.hateoas.server.EntityLinks;
+import org.springframework.hateoas.server.ExposesResourceFor;
 import org.springframework.hateoas.Link;
-import org.springframework.hateoas.PagedResources;
-import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.hateoas.EntityModel;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -69,14 +69,14 @@ public class MetadataFileController {
     private EntityLinks entityLinks;
 
     @RequestMapping(value = "", method = RequestMethod.GET)
-    public HttpEntity<PagedResources<Resource<MetadataFile>>> getFilesPage(
+    public HttpEntity<PagedModel<EntityModel<MetadataFile>>> getFilesPage(
             @PathVariable("imagesCollectionId") String imagesCollectionId,
             @PageableDefault Pageable pageable,
             PagedResourcesAssembler<MetadataFile> assembler) {
         Page<MetadataFile> files = metadataFileRepository.findByImagesCollection(
                 imagesCollectionId, pageable);
-        PagedResources<Resource<MetadataFile>> resources
-                = assembler.toResource(files);
+        PagedModel<EntityModel<MetadataFile>> resources
+                = assembler.toModel(files);
         resources.forEach(
                 resource -> processResource(imagesCollectionId, resource));
         return new ResponseEntity<>(resources, HttpStatus.OK);
@@ -139,10 +139,10 @@ public class MetadataFileController {
     }
 
     protected void processResource(String imagesCollectionId,
-            Resource<MetadataFile> resource) {
+            EntityModel<MetadataFile> resource) {
         MetadataFile file = resource.getContent();
 
-        Link link = entityLinks.linkForSingleResource(
+        Link link = entityLinks.linkForItemResource(
                 ImagesCollection.class, imagesCollectionId)
                 .slash("metadataFiles")
                 .slash(file.getFileName())

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/jupyternotebook/NotebookResourceProcessor.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/jupyternotebook/NotebookResourceProcessor.java
@@ -11,11 +11,11 @@
  */
 package gov.nist.itl.ssd.wipp.backend.data.jupyternotebook;
 
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 import org.springframework.hateoas.Link;
-import org.springframework.hateoas.Resource;
-import org.springframework.hateoas.ResourceProcessor;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.stereotype.Component;
 
 /**
@@ -23,10 +23,10 @@ import org.springframework.stereotype.Component;
 * @author Mohamed Ouladi <mohamed.ouladi at nist.gov>
 */
 @Component
-public class NotebookResourceProcessor implements ResourceProcessor<Resource<Notebook>>{
+public class NotebookResourceProcessor implements RepresentationModelProcessor<EntityModel<Notebook>>{
 	
 	@Override
-	public Resource<Notebook> process(Resource<Notebook> resource) {
+	public EntityModel<Notebook> process(EntityModel<Notebook> resource) {
 		Notebook notebook = resource.getContent();
         
         Link fileLink = linkTo(NotebookGetFileController.class,

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/pyramid/PyramidResourceProcessor.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/pyramid/PyramidResourceProcessor.java
@@ -13,10 +13,11 @@ package gov.nist.itl.ssd.wipp.backend.data.pyramid;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Link;
-import org.springframework.hateoas.Resource;
-import org.springframework.hateoas.ResourceProcessor;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.IanaLinkRelations;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
 
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 import org.springframework.stereotype.Component;
 
@@ -29,15 +30,15 @@ import gov.nist.itl.ssd.wipp.backend.data.pyramid.timeslices.PyramidTimeSliceCon
 * @author Antoine Vandecreme <antoine.vandecreme at nist.gov>
 */
 @Component
-public class PyramidResourceProcessor implements ResourceProcessor<Resource<Pyramid>>{
+public class PyramidResourceProcessor implements RepresentationModelProcessor<EntityModel<Pyramid>>{
 	
 	@Autowired
     private PaginationParameterTemplatesHelper assembler;
 
     @Override
-    public Resource<Pyramid> process(Resource<Pyramid> resource) {
+    public EntityModel<Pyramid> process(EntityModel<Pyramid> resource) {
         Pyramid pyramid = resource.getContent();
-        String selfUri = resource.getId().getHref();
+        String selfUri = resource.getLink(IanaLinkRelations.SELF).get().getHref();
         String pyramidBaseUri = CoreConfig.BASE_URI + "/pyramids/"
                 + pyramid.getId();
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/pyramid/timeslices/PyramidTimeSliceController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/pyramid/timeslices/PyramidTimeSliceController.java
@@ -30,12 +30,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedResourcesAssembler;
-import org.springframework.hateoas.EntityLinks;
-import org.springframework.hateoas.ExposesResourceFor;
+import org.springframework.hateoas.server.EntityLinks;
+import org.springframework.hateoas.server.ExposesResourceFor;
 import org.springframework.hateoas.Link;
-import org.springframework.hateoas.LinkBuilder;
-import org.springframework.hateoas.PagedResources;
-import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.server.LinkBuilder;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.hateoas.EntityModel;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -61,7 +61,7 @@ public class PyramidTimeSliceController {
 	    private EntityLinks entityLinks;
 
 	    @RequestMapping(value = "", method = RequestMethod.GET)
-	    public HttpEntity<PagedResources<Resource<PyramidTimeSlice>>>
+	    public HttpEntity<PagedModel<EntityModel<PyramidTimeSlice>>>
 	            getTimeSlicesPage(
 	                    @PathVariable("pyramidId") String pyramidId,
 	                    @PageableDefault Pageable pageable,
@@ -72,7 +72,7 @@ public class PyramidTimeSliceController {
 	        for (PyramidTimeSlice pts : page) {
 	            processResource(pyramidId, pts);
 	        }
-	        return new ResponseEntity<>(assembler.toResource(page), HttpStatus.OK);
+	        return new ResponseEntity<>(assembler.toModel(page), HttpStatus.OK);
 	    }
 
 	    @RequestMapping(value = "/{timeSliceId}", method = RequestMethod.GET)

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/pyramidannotation/PyramidAnnotationResourceProcessor.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/pyramidannotation/PyramidAnnotationResourceProcessor.java
@@ -18,25 +18,25 @@ import org.springframework.stereotype.Component;
 import gov.nist.itl.ssd.wipp.backend.core.rest.PaginationParameterTemplatesHelper;
 import gov.nist.itl.ssd.wipp.backend.data.pyramidannotation.timeslices.PyramidAnnotationTimeSliceController;
 
-import org.springframework.hateoas.Resource;
-import org.springframework.hateoas.ResourceProcessor;
-import org.springframework.hateoas.mvc.ControllerLinkBuilder;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 
 /**
  * @author Mohamed Ouladi <mohamed.ouladi at nist.gov>
  */
 @Component
-public class PyramidAnnotationResourceProcessor implements ResourceProcessor<Resource<PyramidAnnotation>> {
+public class PyramidAnnotationResourceProcessor implements RepresentationModelProcessor<EntityModel<PyramidAnnotation>> {
 
     @Autowired
     private PaginationParameterTemplatesHelper assembler;
 
     @Override
-    public Resource<PyramidAnnotation> process(
-            Resource<PyramidAnnotation> resource) {
+    public EntityModel<PyramidAnnotation> process(
+            EntityModel<PyramidAnnotation> resource) {
     	PyramidAnnotation annotation = resource.getContent();
 
-        Link link = ControllerLinkBuilder.linkTo(
+        Link link = WebMvcLinkBuilder.linkTo(
                 PyramidAnnotationTimeSliceController.class, annotation.getId())
                 .withRel("timeSlices");
         resource.add(assembler.appendPaginationParameterTemplates(link));

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/pyramidannotation/timeslices/PyramidAnnotationTimeSliceController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/pyramidannotation/timeslices/PyramidAnnotationTimeSliceController.java
@@ -35,12 +35,12 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedResourcesAssembler;
-import org.springframework.hateoas.EntityLinks;
-import org.springframework.hateoas.ExposesResourceFor;
+import org.springframework.hateoas.server.EntityLinks;
+import org.springframework.hateoas.server.ExposesResourceFor;
 import org.springframework.hateoas.Link;
-import org.springframework.hateoas.LinkBuilder;
-import org.springframework.hateoas.PagedResources;
-import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.server.LinkBuilder;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.hateoas.EntityModel;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -80,7 +80,7 @@ public class PyramidAnnotationTimeSliceController {
 	private EntityLinks entityLinks;
 
 	@RequestMapping(value = "", method = RequestMethod.GET)
-	public HttpEntity<PagedResources<Resource<PyramidAnnotationTimeSlice>>>
+	public HttpEntity<PagedModel<EntityModel<PyramidAnnotationTimeSlice>>>
 	getTimeSlicesPage(
 			@PathVariable("pyramidAnnotationId") String pyramidAnnotationId,
 			@PageableDefault Pageable pageable,
@@ -92,7 +92,7 @@ public class PyramidAnnotationTimeSliceController {
 		for (PyramidAnnotationTimeSlice pats : page) {
 			processResource(pyramidAnnotationId, pats);
 		}
-		return new ResponseEntity<>(assembler.toResource(page), HttpStatus.OK);
+		return new ResponseEntity<>(assembler.toModel(page), HttpStatus.OK);
 	}
 
 	@RequestMapping(value = "/{timeSliceId}", method = RequestMethod.GET)

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/stitching/StitchingVectorResourceProcessor.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/stitching/StitchingVectorResourceProcessor.java
@@ -13,9 +13,9 @@ package gov.nist.itl.ssd.wipp.backend.data.stitching;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Link;
-import org.springframework.hateoas.Resource;
-import org.springframework.hateoas.ResourceProcessor;
-import org.springframework.hateoas.mvc.ControllerLinkBuilder;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.stereotype.Component;
 
 import gov.nist.itl.ssd.wipp.backend.data.stitching.timeslices.StitchingVectorTimeSliceController;
@@ -27,7 +27,7 @@ import gov.nist.itl.ssd.wipp.backend.core.rest.PaginationParameterTemplatesHelpe
  */
 @Component
 public class StitchingVectorResourceProcessor
-        implements ResourceProcessor<Resource<StitchingVector>> {
+        implements RepresentationModelProcessor<EntityModel<StitchingVector>> {
 
     @Autowired
     private StitchingVectorRepository stitchingVectorRepository;
@@ -36,18 +36,18 @@ public class StitchingVectorResourceProcessor
     private PaginationParameterTemplatesHelper assembler;
 
     @Override
-    public Resource<StitchingVector> process(
-            Resource<StitchingVector> resource) {
+    public EntityModel<StitchingVector> process(
+            EntityModel<StitchingVector> resource) {
         StitchingVector vector = resource.getContent();
 
-        Link link = ControllerLinkBuilder.linkTo(
+        Link link = WebMvcLinkBuilder.linkTo(
                 StitchingVectorTimeSliceController.class, vector.getId())
                 .withRel("timeSlices");
         resource.add(assembler.appendPaginationParameterTemplates(link));
 
         if (stitchingVectorRepository.getStatisticsFile(
                 vector.getId()).exists()) {
-            link = ControllerLinkBuilder.linkTo(
+            link = WebMvcLinkBuilder.linkTo(
                     StitchingVectorStatisticsController.class, vector.getId())
                     .withRel("statistics");
             resource.add(link);

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/stitching/timeslices/StitchingVectorTimeSliceController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/stitching/timeslices/StitchingVectorTimeSliceController.java
@@ -32,12 +32,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedResourcesAssembler;
-import org.springframework.hateoas.EntityLinks;
-import org.springframework.hateoas.ExposesResourceFor;
+import org.springframework.hateoas.server.EntityLinks;
+import org.springframework.hateoas.server.ExposesResourceFor;
 import org.springframework.hateoas.Link;
-import org.springframework.hateoas.LinkBuilder;
-import org.springframework.hateoas.PagedResources;
-import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.server.LinkBuilder;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.hateoas.EntityModel;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -72,7 +72,7 @@ public class StitchingVectorTimeSliceController {
     private EntityLinks entityLinks;
 
     @RequestMapping(value = "", method = RequestMethod.GET)
-    public HttpEntity<PagedResources<Resource<StitchingVectorTimeSlice>>>
+    public HttpEntity<PagedModel<EntityModel<StitchingVectorTimeSlice>>>
             getTimeSlicesPage(
                     @PathVariable("stitchingVectorId") String stitchingVectorId,
                     @PageableDefault Pageable pageable,
@@ -84,7 +84,7 @@ public class StitchingVectorTimeSliceController {
         for (StitchingVectorTimeSlice svts : page) {
             processResource(stitchingVectorId, svts);
         }
-        return new ResponseEntity<>(assembler.toResource(page), HttpStatus.OK);
+        return new ResponseEntity<>(assembler.toModel(page), HttpStatus.OK);
     }
 
     @RequestMapping(value = "/{timeSliceId}", method = RequestMethod.GET)

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/tensorflowmodels/TensorflowModelResourceProcessor.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/tensorflowmodels/TensorflowModelResourceProcessor.java
@@ -11,10 +11,10 @@
  */
 package gov.nist.itl.ssd.wipp.backend.data.tensorflowmodels;
 
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import org.springframework.hateoas.Link;
-import org.springframework.hateoas.Resource;
-import org.springframework.hateoas.ResourceProcessor;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
 import org.springframework.stereotype.Component;
 
 /**
@@ -22,10 +22,10 @@ import org.springframework.stereotype.Component;
 * @author Mohamed Ouladi <mohamed.ouladi at nist.gov>
 */
 @Component
-public class TensorflowModelResourceProcessor implements ResourceProcessor<Resource<TensorflowModel>> {
+public class TensorflowModelResourceProcessor implements RepresentationModelProcessor<EntityModel<TensorflowModel>> {
 
 	@Override
-	public Resource<TensorflowModel> process(Resource<TensorflowModel> resource) {
+	public EntityModel<TensorflowModel> process(EntityModel<TensorflowModel> resource) {
 		TensorflowModel tm = resource.getContent();
 		
         Link downloadLink = linkTo(TensorflowModelDownloadController.class,

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/VisualizationResourceProcessor.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/VisualizationResourceProcessor.java
@@ -12,10 +12,10 @@
 package gov.nist.itl.ssd.wipp.backend.data.visualization;
 
 import org.springframework.hateoas.Link;
-import org.springframework.hateoas.Resource;
-import org.springframework.hateoas.ResourceProcessor;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.RepresentationModelProcessor;
 
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 import org.springframework.stereotype.Component;
 
@@ -25,10 +25,10 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class VisualizationResourceProcessor
-        implements ResourceProcessor<Resource<Visualization>> {
+        implements RepresentationModelProcessor<EntityModel<Visualization>> {
 
     @Override
-    public Resource<Visualization> process(Resource<Visualization> resource) {
+    public EntityModel<Visualization> process(EntityModel<Visualization> resource) {
 
         Link downloadLink = linkTo(VisualizationDownloadController.class,
                 resource.getContent().getId())

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/BaseUrlManualRefSerializer.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/BaseUrlManualRefSerializer.java
@@ -14,7 +14,7 @@ package gov.nist.itl.ssd.wipp.backend.data.visualization.manifest.layers;
 import java.io.IOException;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.hateoas.EntityLinks;
+import org.springframework.hateoas.server.EntityLinks;
 import org.springframework.hateoas.Link;
 import org.springframework.stereotype.Component;
 
@@ -46,7 +46,7 @@ public class BaseUrlManualRefSerializer extends JsonSerializer<String> {
 	public void serialize(String value, JsonGenerator gen, SerializerProvider sp)
 			throws IOException, JsonProcessingException {
 		if (value != null) {
-			Link link = entityLinks.linkToSingleResource(
+			Link link = entityLinks.linkToItemResource(
                     Pyramid.class,
                     value
             );

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/FetchingUrlManualRefSerializer.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/FetchingUrlManualRefSerializer.java
@@ -11,7 +11,7 @@
  */
 package gov.nist.itl.ssd.wipp.backend.data.visualization.manifest.layers;
 
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 import java.io.IOException;
 


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Upgrade Spring Boot to 2.2.9 (latest 2.2.x release).
Noticeable changes: this new version includes spring-hateoas 1.0, which is breaking with the following renaming of classes (among others):
- `ResourceSupport` is now `RepresentationModel`
- `Resource<T>` is now `EntityModel<T>`
- `Resources<T>` is now `CollectionModel<T>`
- `PagedResources<T>` is now `PagedModel<T>`

Migration was done following the [Spring Boot](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.2-Release-Notes), [Spring Framework](https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-5.x#upgrading-to-version-52), [Spring hateoas](https://spring.io/blog/2019/03/05/spring-hateoas-1-0-m1-released#overhaul) and [Spring Data](https://spring.io/blog/2019/10/08/what-s-new-in-spring-data-moore) migration guides.

## Related issues

The upgrade will allow for the upgrade of Springfox Swagger to the latest version (#148 )