### PR TITLE
fix: admin access to pyramid files

### DIFF
--- a/wipp-backend-application/src/main/java/gov/nist/itl/ssd/wipp/backend/app/SecurityConfig.java
+++ b/wipp-backend-application/src/main/java/gov/nist/itl/ssd/wipp/backend/app/SecurityConfig.java
@@ -95,7 +95,7 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter
 				.antMatchers(HttpMethod.DELETE).authenticated()
 				// restrict wdzt pyramid files access to users authorized to access the pyramid
 				.antMatchers(CoreConfig.PYRAMIDS_BASE_URI + "/{pyramidId}/**")
-					.access("@pyramidSecurity.checkAuthorize(#pyramidId, false)")
+					.access("hasRole('admin') or @pyramidSecurity.checkAuthorize(#pyramidId, false)")
 			// return 401 Unauthorized instead of 302 redirect to login page 
 			// for unauthorized access by anonymous user
 			.and()			


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Fix: user with `admin` role was not able to load pyramids
