### PR TITLE
feat: make ome converter threads configurable

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -17,6 +17,7 @@ sed -i.bak \
     -e "s|ELASTIC_APM_URL_VALUE|${ELASTIC_APM_URL}|g" \
     -e "s|NODE_SELECTOR_VALUE|${NODE_SELECTOR}|g" \
     -e "s|TOLERATIONS_VALUE|${TOLERATIONS}|g" \
+    -e "s|OME_CONVERTER_THREADS_VALUE|${OME_CONVERTER_THREADS}|g" \
     deploy/kubernetes/backend-deployment.yaml
 rm deploy/kubernetes/backend-deployment.yaml.bak
 

--- a/deploy/docker/application.properties
+++ b/deploy/docker/application.properties
@@ -29,7 +29,7 @@ storage.collections.upload.tmp=/data/WIPP-plugins/temp/collections
 storage.stitching=/data/WIPP-plugins/stitching
 
 # Image OME TIFF conversion configuration
-ome.converter.threads=6
+ome.converter.threads=@ome_converter_threads@
 
 # Image upload - Flow.js configuration
 spring.servlet.multipart.maxFileSize=5MB

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -23,6 +23,10 @@ if [[ -z $KEYCLOAK_DISABLE_TRUST_MANAGER ]]; then
   KEYCLOAK_DISABLE_TRUST_MANAGER="false"
 fi
 
+if [[ -z $OME_CONVERTER_THREADS ]]; then
+  OME_CONVERTER_THREADS="6"
+fi
+
 sed -i \
   -e 's/@mongo_host@/'"${MONGO_HOST}"'/' \
   -e 's/@mongo_port@/'"${MONGO_PORT}"'/' \
@@ -32,6 +36,7 @@ sed -i \
   -e 's|@keycloak_disable_trust_manager@|'"${KEYCLOAK_DISABLE_TRUST_MANAGER}"'|' \
   -e 's|@workflow_nodeSelector@|'"${NODE_SELECTOR}"'|' \
   -e 's|@workflow_tolerations@|'"${TOLERATIONS}"'|' \
+  -e 's|@ome_converter_threads@|'"${OME_CONVERTER_THREADS}"'|' \
   /opt/wipp/config/application.properties
 
 if [[ -n ${ELASTIC_APM_SERVER_URLS} && -n ${ELASTIC_APM_SERVICE_NAME} ]]; then

--- a/deploy/kubernetes/backend-deployment.yaml
+++ b/deploy/kubernetes/backend-deployment.yaml
@@ -61,6 +61,8 @@ spec:
               value: NODE_SELECTOR_VALUE
             - name: TOLERATIONS
               value: TOLERATIONS_VALUE
+            - name: OME_CONVERTER_THREADS
+              value: OME_CONVERTER_THREADS_VALUE
           volumeMounts:
             - mountPath: /data/WIPP-plugins
               name: data

--- a/sample-env
+++ b/sample-env
@@ -8,6 +8,8 @@ ELASTIC_APM_URL=<url to Elastic APM>
 NODE_SELECTOR=<node selector in the format "key1:value1;key2:value2;">
 TOLERATIONS=<pod tolerations in the format "key1:operator1:value1:effect1;", optional values can be skipped "key1:operator1::;">
 
+OME_CONVERTER_THREADS=<number of concurrent threads for image conversion, default is 6>
+
 BACKEND_HOST_NAME=<host name>
 MONGO_HOST_NAME=<host name>
 TENSORBOARD_HOST_NAME=<host name>


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Make number of concurrent threads used for uploaded image conversion configurable:
- number of threads can be configured by setting the `OME_CONVERTER_THREADS` env variable (see `sample-env` file),
- if `OME_CONVERTER_THREADS` is not set default value is 6

## Related issues

See #165 