### PR TITLE
fix: argo binary download url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir -p \
 RUN wget https://repo1.maven.org/maven2/co/elastic/apm/elastic-apm-agent/${APM_VERSION}/elastic-apm-agent-${APM_VERSION}.jar -O ${EXEC_DIR}/elastic-apm-agent.jar
 
 # Install Argo CLI executable
-RUN wget https://github.com/argoproj/argo/releases/download/${ARGO_VERSION}/argo-linux-amd64 && \
+RUN wget https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VERSION}/argo-linux-amd64 && \
     chmod +x argo-linux-amd64 && \
     mv argo-linux-amd64 /usr/local/bin/argo
 


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Update Argo binary download URL in Dockerfile.

Argo Github repo has been renamed from `argoproj/argo` to `argoproj/argo-workflows` for some time, but `argoproj/argo` is now redirecting to `argoproj/argocon21` instead of `argoproj/argo-workflows`, breaking the Docker build.
