### PR TITLE
docs: Fix Swagger UI URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ mvn spring-boot:run
 - The WIPP REST API will be launched with the `dev` profile and available at http://localhost:8080/api  
 
 - Swagger API documentation will be available at:
- - http://localhost:8080/swagger-ui.html (Swagger UI) and,
+ - http://localhost:8080/swagger-ui/index.html (Swagger UI) and,
  - http://localhost:8080/v2/api-docs (OpenAPI spec)
 
 ## Docker packaging


### PR DESCRIPTION
## What does this PR do?

Fixes the docs to point to the correct URL for Swagger UI

## Related issues

https://github.com/usnistgov/WIPP-frontend/pull/189
