### PR TITLE
feat: Fully containerized build

### DIFF
--- a/Dockerfile.localdev
+++ b/Dockerfile.localdev
@@ -1,30 +1,9 @@
-
-# Stage 0: Build image
-FROM maven:3.8.3-jdk-8
-
-ARG BACKEND_ROOT="WIPP-backend"
-ARG BACKEND_APP="wipp-backend-application"
-ARG BACKEND_DATA="wipp-backend-data"
-ARG BACKEND_CORE="wipp-backend-core"
-ARG BACKEND_ARGO="wipp-backend-argo-workflows"
-
-COPY pom.xml /usr/local/${BACKEND_ROOT}/pom.xml
-COPY ${BACKEND_NAME} /usr/local/${BACKEND_ROOT}/${BACKEND_NAME}
-COPY ${BACKEND_DATA} /usr/local/${BACKEND_ROOT}/${BACKEND_DATA}
-COPY ${BACKEND_CORE} /usr/local/${BACKEND_ROOT}/${BACKEND_CORE}
-COPY ${BACKEND_ARGO} /usr/local/${BACKEND_ROOT}/${BACKEND_ARGO}
-COPY deploy/docker/maven-settings.xml /usr/share/maven/conf/settings.xml
-WORKDIR /usr/local/${BACKEND_ROOT}
-RUN mvn clean package -P prod
-
-# Stage 1: Runtime image
 FROM openjdk:8-jdk-alpine
 LABEL org.opencontainers.image.authors="National Institute of Standards and Technology"
 
 EXPOSE 8080
 
-ARG BACKEND_ROOT="WIPP-backend"
-ARG BACKEND_APP="wipp-backend-application"
+ARG BACKEND_NAME="wipp-backend-application"
 ARG EXEC_DIR="/opt/wipp"
 ARG DATA_DIR="/data/WIPP-plugins"
 ARG ARGO_VERSION="v2.3.0"
@@ -45,8 +24,8 @@ RUN wget https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VER
     chmod +x argo-linux-amd64 && \
     mv argo-linux-amd64 /usr/local/bin/argo
 
-# Copy WIPP backend application exec WAR from the previous stage
-COPY --from=0 /usr/local/${BACKEND_ROOT}/${BACKEND_APP}/target/${BACKEND_APP}-*-exec.war ${EXEC_DIR}/wipp-backend.war
+# Copy WIPP backend application exec WAR
+COPY ${BACKEND_NAME}/target/${BACKEND_NAME}-*-exec.war ${EXEC_DIR}/wipp-backend.war
 
 # Copy properties and entrypoint script
 COPY deploy/docker/application.properties ${EXEC_DIR}/config

--- a/README.md
+++ b/README.md
@@ -55,11 +55,22 @@ mvn spring-boot:run
  - http://localhost:8080/v2/api-docs (OpenAPI spec)
 
 ## Docker packaging
+There are two ways to build Docker images for WIPP-backend:
+
+- For local development, first compile the project (so it produces `wipp-backend-application/target/wipp-backend-application-...-exec.war`), then build Docker image from `Dockerfile.localdev`.
+
 The Maven `prod` profile should be used for Docker packaging, even for testing/development purposes:
 ```sh
 mvn clean package -P prod
+docker build --no-cache -f Dockerfile.localdev . -t wipp_backend
+```
+
+- For CI builds or if you don't have Java/Maven installed on host, simply build Docker image from `Dockerfile`
+```sh
 docker build --no-cache . -t wipp_backend
 ```
+
+
 For a Docker deployment of WIPP on a Kubernetes cluster, scripts and configuration files are available in the [WIPP repository](https://github.com/usnistgov/WIPP/tree/master/deployment).
 
 ## Deployment

--- a/deploy/docker/maven-settings.xml
+++ b/deploy/docker/maven-settings.xml
@@ -1,0 +1,15 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                     http://maven.apache.org/xsd/settings-1.0.0.xsd">
+ <localRepository/>
+ <interactiveMode/>
+ <usePluginRegistry/>
+ <offline/>
+ <pluginGroups/>
+ <servers/>
+ <mirrors/>
+ <proxies/>
+ <profiles/>
+ <activeProfiles/>
+</settings>


### PR DESCRIPTION
## What does this PR do?

- Renames the existing `Dockerfile` to `Dockerfile.localdev` as this file requires building of the Java artifact on the host (and therefore Java/Maven installed). This Dockerfile facilitates a rapid development mode when developer has all the tools installed on the host machine and changes code frequently.
- Adds a new `Dockerfile` which utilizes two-stage build and does not require anything to be installed on the host other than Docker to produce the final image. First stage uses official Maven image (`maven:3.8.3-jdk-8`) to build the Java artifact; second stage uses the same `openjdk:8-jdk-alpine` image as before for the runtime image. The first stage is only used to build the artifact and then simply discarded (like a rocket stages do), so we don't carry Maven tools into production container. This Dockerfile is meant for CI pipelines or users who can't/don't want to install Java/Maven toolchain on their host machine, but still want to build the latest Docker image from WIPP-backend repo.
- Replaces the obsolete `MAINTAINER` tag in favor of the label `org.opencontainers.image.authors` as recommended in the official docs: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated.
- Adds README instructions on usage of both Dockerfiles