### PR TITLE
Feature/upgrade spring boot 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Requirements for development environment setup.
 * Maven version compatible with Java 8
 
 ### Database
-* MongoDB 3.6
+* MongoDB (Supported versions: 3.6 to 4.4)
 
 ### Identity and Access Management
 * Keycloak 11.0.2

--- a/wipp-backend-application/pom.xml
+++ b/wipp-backend-application/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.9.RELEASE</version>
+		<version>2.3.12.RELEASE</version>
 		<relativePath />
 	</parent>
 

--- a/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/core/model/job/JobRepositoryTest.java
+++ b/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/core/model/job/JobRepositoryTest.java
@@ -12,6 +12,7 @@
 package gov.nist.itl.ssd.wipp.backend.core.model.job;
 
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.*;

--- a/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/core/model/workflow/WorkflowRepositoryTest.java
+++ b/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/core/model/workflow/WorkflowRepositoryTest.java
@@ -12,6 +12,7 @@
 package gov.nist.itl.ssd.wipp.backend.core.model.workflow;
 
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.*;

--- a/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/csvcollection/CsvCollectionRepositoryTest.java
+++ b/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/csvcollection/CsvCollectionRepositoryTest.java
@@ -12,6 +12,7 @@
 package gov.nist.itl.ssd.wipp.backend.data.csvcollection;
 
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.*;

--- a/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/genericdata/GenericDataRepositoryTest.java
+++ b/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/genericdata/GenericDataRepositoryTest.java
@@ -13,7 +13,7 @@ package gov.nist.itl.ssd.wipp.backend.data.genericdata;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;

--- a/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/ImagesCollectionRepositoryTest.java
+++ b/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/ImagesCollectionRepositoryTest.java
@@ -12,6 +12,7 @@
 package gov.nist.itl.ssd.wipp.backend.data.imagescollection;
 
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.*;

--- a/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/jupyternotebook/NotebookRepositoryTest.java
+++ b/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/jupyternotebook/NotebookRepositoryTest.java
@@ -12,6 +12,7 @@
 package gov.nist.itl.ssd.wipp.backend.data.jupyternotebook;
 
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.*;

--- a/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/pyramid/PyramidRepositoryTest.java
+++ b/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/pyramid/PyramidRepositoryTest.java
@@ -12,6 +12,7 @@
 package gov.nist.itl.ssd.wipp.backend.data.pyramid;
 
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.*;

--- a/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/stitching/StitchingVectorRepositoryTest.java
+++ b/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/stitching/StitchingVectorRepositoryTest.java
@@ -12,6 +12,7 @@
 package gov.nist.itl.ssd.wipp.backend.data.stitching;
 
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.*;

--- a/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/tensorboard/TensorboardLogsRepositoryTest.java
+++ b/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/tensorboard/TensorboardLogsRepositoryTest.java
@@ -12,6 +12,7 @@
 package gov.nist.itl.ssd.wipp.backend.data.tensorboard;
 
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.*;

--- a/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/tensorflowmodels/TensorflowModelRepositoryTest.java
+++ b/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/tensorflowmodels/TensorflowModelRepositoryTest.java
@@ -12,6 +12,7 @@
 package gov.nist.itl.ssd.wipp.backend.data.tensorflowmodels;
 
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.*;

--- a/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/visualization/VisualizationRepositoryTest.java
+++ b/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/data/visualization/VisualizationRepositoryTest.java
@@ -12,6 +12,7 @@
 package gov.nist.itl.ssd.wipp.backend.data.visualization;
 
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.*;

--- a/wipp-backend-core/pom.xml
+++ b/wipp-backend-core/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.9.RELEASE</version>
+		<version>2.3.12.RELEASE</version>
 		<relativePath />
 	</parent>
 	<groupId>gov.nist.itl.ssd.wipp</groupId>
@@ -16,7 +16,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<spring-mvc-cache-control.version>1.1.1-RELEASE</spring-mvc-cache-control.version>
-		<springboot-version>2.2.9.RELEASE</springboot-version>
+		<springboot-version>2.3.12.RELEASE</springboot-version>
 	</properties>
 
 	<repositories>

--- a/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/rest/PaginationParameterTemplatesHelper.java
+++ b/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/rest/PaginationParameterTemplatesHelper.java
@@ -24,7 +24,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  * @author Mylene Simon <mylene.simon at nist.gov>
  *
  * This helper adds pagination parameters templates to links, since it was removed from
- * method appendPaginationParameterTemplates of classe PageableHandlerMethodArgumentResolver
+ * method appendPaginationParameterTemplates of class PageableHandlerMethodArgumentResolver
  * as of Spring-data 1.11
  * See issue http://stackoverflow.com/questions/34518885/how-to-add-pagination-templates-in-the-links-with-spring-data-1-11
  */
@@ -42,7 +42,7 @@ public class PaginationParameterTemplatesHelper {
  		Assert.notNull(link, "Link must not be null!");
 
 		String uri = link.getHref();
-		UriTemplate uriTemplate = new UriTemplate(uri);
+		UriTemplate uriTemplate = UriTemplate.of(uri);
 		UriComponents uriComponents = UriComponentsBuilder.fromUriString(uri).build();
 		TemplateVariables variables = pageableResolver.getPaginationTemplateVariables(null, uriComponents);
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/genericdata/GenericData.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/genericdata/GenericData.java
@@ -71,6 +71,10 @@ public class GenericData {
 	
 	public GenericData() {
 	}
+	
+	public GenericData(String name){
+		this(name, false);
+	}
 
 	public GenericData(String name, boolean locked){
 		this.name = name;

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/genericdata/GenericDataLogic.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/genericdata/GenericDataLogic.java
@@ -1,6 +1,7 @@
 package gov.nist.itl.ssd.wipp.backend.data.genericdata;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import gov.nist.itl.ssd.wipp.backend.core.rest.exception.ClientException;
 
@@ -9,6 +10,7 @@ import gov.nist.itl.ssd.wipp.backend.core.rest.exception.ClientException;
 *
 * @author Mohamed Ouladi <mohamed.ouladi at labshare.org>
 */
+@Component
 public class GenericDataLogic {
 	
     @Autowired

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageController.java
@@ -20,7 +20,6 @@ import gov.nist.itl.ssd.wipp.backend.core.rest.exception.ClientException;
 import gov.nist.itl.ssd.wipp.backend.core.rest.exception.ForbiddenException;
 import gov.nist.itl.ssd.wipp.backend.core.rest.exception.NotFoundException;
 import gov.nist.itl.ssd.wipp.backend.data.imagescollection.ImagesCollection;
-import gov.nist.itl.ssd.wipp.backend.data.imagescollection.ImagesCollectionDownloadController;
 import gov.nist.itl.ssd.wipp.backend.data.imagescollection.ImagesCollectionRepository;
 import io.swagger.annotations.Api;
 
@@ -284,7 +283,7 @@ public class ImageController {
 		TemplateVariable tv = new TemplateVariable("regex",
 				TemplateVariable.VariableType.REQUEST_PARAM);
 
-		UriTemplate uriTemplate = new UriTemplate(imagesFilterLink.getHref(),
+		UriTemplate uriTemplate = UriTemplate.of(imagesFilterLink.getHref(),
 				new TemplateVariables(tv));
 
 		Link link = new Link(uriTemplate, "filterByFileNameRegex");


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Upgrade Spring Boot version to 2.13.2:
- change deprecated methods,
- add support for MongoDB 4.x (up to 4.4)

Minor fixes to GenericData package


