### PR TITLE
feat: swagger auth

### DIFF
--- a/docs/auth-acl/realm-export.json
+++ b/docs/auth-acl/realm-export.json
@@ -751,11 +751,15 @@
       "secret": "**********",
       "redirectUris": [
         "http://localhost:4200/*",
-        "https://localhost:4200/*"
+        "https://localhost:4200/*",
+        "http://localhost:8080/api/swagger-ui/oauth2-redirect.html",
+        "https://localhost:8080/api/swagger-ui/oauth2-redirect.html"
       ],
       "webOrigins": [
         "https://localhost:4200",
-        "http://localhost:4200"
+        "http://localhost:4200",
+        "http://localhost:8080",
+        "https://localhost:8080"
       ],
       "notBefore": 0,
       "bearerOnly": false,

--- a/wipp-backend-application/src/main/java/gov/nist/itl/ssd/wipp/backend/Application.java
+++ b/wipp-backend-application/src/main/java/gov/nist/itl/ssd/wipp/backend/Application.java
@@ -144,8 +144,6 @@ public class Application implements WebMvcConfigurer {
           .paths(PathSelectors.any()) 
           .paths(PathSelectors.regex("/error.*").negate())
           .paths(PathSelectors.regex("/api/profile").negate())
-      	  // workaround to avoid duplicate entries for plugins
-          .paths(PathSelectors.regex("/api/plugins").negate())
           .build() 
           // manually create tags to manage custom descriptions
           .tags(
@@ -163,7 +161,7 @@ public class Application implements WebMvcConfigurer {
               new Tag("Visualization Entity", "REST API for Pyramid Visualizations"),
               new Tag("Workflow Entity", "REST API for Workflows"))
           .apiInfo(apiEndPointsInfo())
-          .enableUrlTemplating(true);
+          .enableUrlTemplating(false);
     }
     
     /**


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Feature:
- Enable auth in Swagger UI
  - click on Authorize button from main page, and then Authorize button from pop-up will redirect to Keycloak login page
  - upon successful login Keycloak will redirect to Swagger UI and _try it out_ requests will have the bearer token added to the headers

- Fixes:
  - Fix missing `/api/plugins` endpoints
  - Removed URL templating display that was causing issues in _try it out_ requests

Note: Swagger UI origin and url have to be added to the allowed ones in Keycloak wipp client configuration (see _realm_ changes)
  
## Related issues

Closes #175 and #182 