### PR TITLE
feat: add baseCommand support in manifest

### DIFF
--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/plugin/Plugin.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/plugin/Plugin.java
@@ -9,10 +9,13 @@ import java.util.List;
  *
  * @author Philippe Dessauw <philippe.dessauw at nist.gov>
  * @author Mohamed Ouladi <mohamed.ouladi at nist.gov>
+ * @author Mylene Simon <mylene.simon at nist.gov>
  */
 @IdExposed
 public class Plugin extends Computation {
+    
     private String containerId;
+    private List<String> baseCommand;
 
     private String title;
     private String description;
@@ -32,6 +35,14 @@ public class Plugin extends Computation {
 
     public void setContainerId(String containerId) {
         this.containerId = containerId;
+    }
+
+    public List<String> getBaseCommand() {
+        return baseCommand;
+    }
+
+    public void setBaseCommand(List<String> baseCommand) {
+        this.baseCommand = baseCommand;
     }
 
     public String getTitle() {

--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/spec/ArgoTemplatePluginContainer.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/spec/ArgoTemplatePluginContainer.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 public class ArgoTemplatePluginContainer {
     private String image;
+    private List<String> command;
     private List<String> args;
     private List<Map<String, Object>> volumeMounts;
 
@@ -14,6 +15,14 @@ public class ArgoTemplatePluginContainer {
 
     public void setImage(String image) {
         this.image = image;
+    }
+
+    public List<String> getCommand() {
+        return command;
+    }
+
+    public void setCommand(List<String> command) {
+        this.command = command;
     }
 
     public List<String> getArgs() {

--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowConverter.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowConverter.java
@@ -72,13 +72,17 @@ public class WorkflowConverter {
 
     private ArgoTemplatePluginContainer generateTemplatePluginContainer(
             String containerId,
+            List<String> command,
             List<String> parameters,
             String jobId
     ) {
         ArgoTemplatePluginContainer container = new ArgoTemplatePluginContainer();
 
         container.setImage(containerId);
-
+        if(command != null) {
+        	container.setCommand(command);
+        }
+        
         // Setup the container arguments
         List<String> argoPluginContainerArgs = new ArrayList<>();
         for (String parameter : parameters) {
@@ -134,6 +138,7 @@ public class WorkflowConverter {
         argoTemplatePlugin.setContainer(
                 this.generateTemplatePluginContainer(
                         plugin.getContainerId(),
+                        plugin.getBaseCommand(),
                         parameters,
                         jobId
                 )


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Support for `baseCommand` in WIPP plugin manifest, gets translated to `command` in Argo Workflow manifest if present in WIPP manifest. Enables support for Docker image using `CMD` as opposed to `ENTRYPOINT`, or for overriding the default entrypoint.

Example:
```
{
  "name": "wipp/plugin-name",
  "version": "0.0.1",
  "containerId": "docker.io/wipp/plugin-name:0.1.0",
  "baseCommand": ["python3", "/opt/executable/main.py"]
  "title": "Example plugin",
  "description": "Example plugin description,
  ...
  "inputs": [
    {
      "name": "inpDir",
      "description": "Input image collection to be processed by this plugin",
      "type": "collection",
      "options": null,
      "required": true
    },
  ...
}
```

