### PR TITLE
feat: add developer role

### DIFF
--- a/docs/auth-acl/acl.md
+++ b/docs/auth-acl/acl.md
@@ -3,11 +3,12 @@
 Identity Management in WIPP provided by [Keycloak](https://www.keycloak.org/).
 
 ## WIPP roles
-Currently, three roles are available:
+Currently, four roles are available:
 - *user*: Can create resources, edit its own resources, delete its own unlocked resources, make them public. Can read and use public resources. 
-- *admin*: Can do all of the above on all resources, and register new plugins.
+- *admin*: Can do all of the above on all resources, and register/delete plugins.
+- *developer*: Can do what a regular *user* can do, plus register/delete plugins.
 - *anonymous*: Can read public resources.  
-Roles *user* and *admin* are defined in Keycloak. Role *user* is added by default, *admin* can be added manually to an user from the Keycloak dashboard, see https://www.keycloak.org/docs/latest/server_admin/index.html#user-role-mappings
+Roles *user*, *admin* and *developer* are defined in Keycloak. Role *user* is added by default, *admin* can be added manually to an user from the Keycloak dashboard, see https://www.keycloak.org/docs/latest/server_admin/index.html#user-role-mappings
 
 ## Access Control Lists
 The following table describes which actions a WIPP user can do depending on their role, the resource owner and resource visibility, using the REST API.  
@@ -19,6 +20,9 @@ The following table describes which actions a WIPP user can do depending on thei
   </th>
   <th colspan="5">
     admin
+  </th>
+  <th colspan="5">
+    developer
   </th>
   <th colspan="5">
     user
@@ -43,9 +47,19 @@ The following table describes which actions a WIPP user can do depending on thei
     <td><b>U</b></td>
     <td><b>D</b></td>
     <td><b></b></td>
+    <td><b>C</b></td>
+    <td><b>R</b></td>
+    <td><b>U</b></td>
+    <td><b>D</b></td>
+    <td><b></b></td>
   </tr>
   <tr>
     <td><i>Private (is owner)</i></td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>Y</td>
+    <td></td>
     <td>Y</td>
     <td>Y</td>
     <td>Y</td>
@@ -79,6 +93,11 @@ The following table describes which actions a WIPP user can do depending on thei
     <td>N</td>
     <td>N</td>
     <td></td>
+    <td>X</td>
+    <td>N</td>
+    <td>N</td>
+    <td>N</td>
+    <td></td>
   </tr>
   <tr>
     <td><i>Public (not owner)</i></td>
@@ -86,6 +105,11 @@ The following table describes which actions a WIPP user can do depending on thei
     <td>Y</td>
     <td>Y</td>
     <td>Y</td>
+    <td></td>
+    <td>X</td>
+    <td>Y</td>
+    <td>N</td>
+    <td>N</td>
     <td></td>
     <td>X</td>
     <td>Y</td>
@@ -115,9 +139,19 @@ The following table describes which actions a WIPP user can do depending on thei
     <td><b>U</b></td>
     <td><b>D</b></td>
     <td><b></b></td>
+    <td><b>C</b></td>
+    <td><b>R</b></td>
+    <td><b>U</b></td>
+    <td><b>D</b></td>
+    <td><b></b></td>
   </tr>
   <tr>
     <td><i>Private (is owner)</i></td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>Y</td>
+    <td></td>
     <td>Y</td>
     <td>Y</td>
     <td>Y</td>
@@ -151,6 +185,11 @@ The following table describes which actions a WIPP user can do depending on thei
     <td>N</td>
     <td>N</td>
     <td></td>
+    <td>X</td>
+    <td>N</td>
+    <td>N</td>
+    <td>N</td>
+    <td></td>
   </tr>
   <tr>
     <td><i>Public (not owner)</i></td>
@@ -158,6 +197,11 @@ The following table describes which actions a WIPP user can do depending on thei
     <td>Y</td>
     <td>Y</td>
     <td>Y</td>
+    <td></td>
+    <td>X</td>
+    <td>Y</td>
+    <td>N</td>
+    <td>N</td>
     <td></td>
     <td>X</td>
     <td>Y</td>
@@ -187,9 +231,19 @@ The following table describes which actions a WIPP user can do depending on thei
     <td><b>U</b></td>
     <td><b>D</b></td>
     <td><b></b></td>
+    <td><b>C</b></td>
+    <td><b>R</b></td>
+    <td><b>U</b></td>
+    <td><b>D</b></td>
+    <td><b></b></td>
   </tr>
   <tr>
     <td><i>Private (is owner)</i></td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>N</td>
+    <td></td>
     <td>Y</td>
     <td>Y</td>
     <td>Y</td>
@@ -223,12 +277,22 @@ The following table describes which actions a WIPP user can do depending on thei
     <td>N</td>
     <td>N</td>
     <td></td>
+    <td>X</td>
+    <td>N</td>
+    <td>N</td>
+    <td>N</td>
+    <td></td>
   </tr>
   <tr>
     <td><i>Public (not owner)</i></td>
     <td>X</td>
     <td>Y</td>
     <td>Y</td>
+    <td>N</td>
+    <td></td>
+    <td>X</td>
+    <td>Y</td>
+    <td>N</td>
     <td>N</td>
     <td></td>
     <td>X</td>
@@ -259,9 +323,19 @@ The following table describes which actions a WIPP user can do depending on thei
     <td><b>U</b></td>
     <td><b>D</b></td>
     <td><b></b></td>
+    <td><b>C</b></td>
+    <td><b>R</b></td>
+    <td><b>U</b></td>
+    <td><b>D</b></td>
+    <td><b></b></td>
   </tr>
   <tr>
     <td><i>Private (is owner)</i></td>
+    <td>N</td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>N</td>
+    <td></td>
     <td>N</td>
     <td>Y</td>
     <td>Y</td>
@@ -295,12 +369,22 @@ The following table describes which actions a WIPP user can do depending on thei
     <td>N</td>
     <td>N</td>
     <td></td>
+    <td>X</td>
+    <td>N</td>
+    <td>N</td>
+    <td>N</td>
+    <td></td>
   </tr>
   <tr>
     <td><i>Public (not owner)</i></td>
     <td>X</td>
     <td>Y</td>
     <td>Y</td>
+    <td>N</td>
+    <td></td>
+    <td>X</td>
+    <td>Y</td>
+    <td>N</td>
     <td>N</td>
     <td></td>
     <td>X</td>
@@ -331,9 +415,19 @@ The following table describes which actions a WIPP user can do depending on thei
     <td><b>U</b></td>
     <td><b>D</b></td>
     <td><b></b></td>
+    <td><b>C</b></td>
+    <td><b>R</b></td>
+    <td><b>U</b></td>
+    <td><b>D</b></td>
+    <td><b></b></td>
   </tr>
   <tr>
     <td><i>Private (is owner)</i></td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>N</td>
+    <td></td>
     <td>Y</td>
     <td>Y</td>
     <td>Y</td>
@@ -367,12 +461,22 @@ The following table describes which actions a WIPP user can do depending on thei
     <td>N</td>
     <td>N</td>
     <td></td>
+    <td>X</td>
+    <td>N</td>
+    <td>N</td>
+    <td>N</td>
+    <td></td>
   </tr>
   <tr>
     <td><i>Public (not owner)</i></td>
     <td>X</td>
     <td>Y</td>
     <td>Y</td>
+    <td>N</td>
+    <td></td>
+    <td>X</td>
+    <td>Y</td>
+    <td>N</td>
     <td>N</td>
     <td></td>
     <td>X</td>
@@ -403,9 +507,19 @@ The following table describes which actions a WIPP user can do depending on thei
     <td><b>U</b></td>
     <td><b>D</b></td>
     <td><b></b></td>
+    <td><b>C</b></td>
+    <td><b>R</b></td>
+    <td><b>U</b></td>
+    <td><b>D</b></td>
+    <td><b></b></td>
   </tr>
   <tr>
     <td><i>Private (is owner)</i></td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>N</td>
+    <td></td>
     <td>Y</td>
     <td>Y</td>
     <td>Y</td>
@@ -439,12 +553,22 @@ The following table describes which actions a WIPP user can do depending on thei
     <td>N</td>
     <td>N</td>
     <td></td>
+    <td>X</td>
+    <td>N</td>
+    <td>N</td>
+    <td>N</td>
+    <td></td>
   </tr>
   <tr>
     <td><i>Public (not owner)</i></td>
     <td>X</td>
     <td>Y</td>
     <td>Y</td>
+    <td>N</td>
+    <td></td>
+    <td>X</td>
+    <td>Y</td>
+    <td>N</td>
     <td>N</td>
     <td></td>
     <td>X</td>
@@ -475,9 +599,19 @@ The following table describes which actions a WIPP user can do depending on thei
     <td><b>U</b></td>
     <td><b>D</b></td>
     <td><b></b></td>
+    <td><b>C</b></td>
+    <td><b>R</b></td>
+    <td><b>U</b></td>
+    <td><b>D</b></td>
+    <td><b></b></td>
   </tr>
   <tr>
     <td><i>Private (is owner)</i></td>
+    <td>N</td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>N</td>
+    <td></td>
     <td>N</td>
     <td>Y</td>
     <td>Y</td>
@@ -511,12 +645,22 @@ The following table describes which actions a WIPP user can do depending on thei
     <td>N</td>
     <td>N</td>
     <td></td>
+    <td>X</td>
+    <td>N</td>
+    <td>N</td>
+    <td>N</td>
+    <td></td>
   </tr>
   <tr>
     <td><i>Public (not owner)</i></td>
     <td>X</td>
     <td>Y</td>
     <td>Y</td>
+    <td>N</td>
+    <td></td>
+    <td>X</td>
+    <td>Y</td>
+    <td>N</td>
     <td>N</td>
     <td></td>
     <td>X</td>
@@ -547,9 +691,19 @@ The following table describes which actions a WIPP user can do depending on thei
     <td><b>U</b></td>
     <td><b>D</b></td>
     <td><b></b></td>
+    <td><b>C</b></td>
+    <td><b>R</b></td>
+    <td><b>U</b></td>
+    <td><b>D</b></td>
+    <td><b></b></td>
   </tr>
   <tr>
     <td><i>Private (is owner)</i></td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>N</td>
+    <td>N</td>
+    <td></td>
     <td>Y</td>
     <td>Y</td>
     <td>N</td>
@@ -583,9 +737,19 @@ The following table describes which actions a WIPP user can do depending on thei
     <td>N</td>
     <td>N</td>
     <td></td>
+    <td>X</td>
+    <td>N</td>
+    <td>N</td>
+    <td>N</td>
+    <td></td>
   </tr>
   <tr>
     <td><i>Public (not owner)</i></td>
+    <td>X</td>
+    <td>Y</td>
+    <td>N</td>
+    <td>N</td>
+    <td></td>
     <td>X</td>
     <td>Y</td>
     <td>N</td>
@@ -619,9 +783,19 @@ The following table describes which actions a WIPP user can do depending on thei
     <td><b>U</b></td>
     <td><b>D</b></td>
     <td><b></b></td>
+    <td><b>C</b></td>
+    <td><b>R</b></td>
+    <td><b>U</b></td>
+    <td><b>D</b></td>
+    <td><b></b></td>
   </tr>
   <tr>
     <td><i>Private (is owner)</i></td>
+    <td>N</td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>N</td>
+    <td></td>
     <td>N</td>
     <td>Y</td>
     <td>Y</td>
@@ -655,6 +829,11 @@ The following table describes which actions a WIPP user can do depending on thei
     <td>N</td>
     <td>N</td>
     <td></td>
+    <td>X</td>
+    <td>N</td>
+    <td>N</td>
+    <td>N</td>
+    <td></td>
   </tr>
   <tr>
     <td><i>Public (not owner)</i></td>
@@ -673,12 +852,22 @@ The following table describes which actions a WIPP user can do depending on thei
     <td>N</td>
     <td>N</td>
     <td></td>
+    <td>X</td>
+    <td>Y</td>
+    <td>N</td>
+    <td>N</td>
+    <td></td>
   </tr>
   <tr>
-    <td collspan="16"></td>
+    <td collspan="21"></td>
   </tr>
   <tr>
     <td><b>Plugins</b></td>
+    <td><b>C</b></td>
+    <td><b>R</b></td>
+    <td><b>U</b></td>
+    <td><b>D</b></td>
+    <td><b></b></td>
     <td><b>C</b></td>
     <td><b>R</b></td>
     <td><b>U</b></td>
@@ -702,6 +891,11 @@ The following table describes which actions a WIPP user can do depending on thei
     <td>Y</td>
     <td>Y</td>
     <td></td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>Y</td>
+    <td></td>
     <td>N</td>
     <td>Y</td>
     <td>N</td>
@@ -714,7 +908,7 @@ The following table describes which actions a WIPP user can do depending on thei
     <td></td>
   </tr>
   <tr>
-    <td collspan="16"></td>
+    <td collspan="21"></td>
   </tr>
   <tr>
     <td><b>Workflows</b></td>
@@ -733,9 +927,19 @@ The following table describes which actions a WIPP user can do depending on thei
     <td><b>U</b></td>
     <td><b>D</b></td>
     <td><b></b></td>
+    <td><b>C</b></td>
+    <td><b>R</b></td>
+    <td><b>U</b></td>
+    <td><b>D</b></td>
+    <td><b></b></td>
   </tr>
   <tr>
     <td><i>Private (is owner)</i></td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>N</td>
+    <td></td>
     <td>Y</td>
     <td>Y</td>
     <td>Y</td>
@@ -769,12 +973,22 @@ The following table describes which actions a WIPP user can do depending on thei
     <td>N</td>
     <td>N</td>
     <td></td>
+    <td>X</td>
+    <td>N</td>
+    <td>N</td>
+    <td>N</td>
+    <td></td>
   </tr>
   <tr>
     <td><i>Public (not owner)</i></td>
     <td>X</td>
     <td>Y</td>
     <td>Y</td>
+    <td>N</td>
+    <td></td>
+    <td>X</td>
+    <td>Y</td>
+    <td>N</td>
     <td>N</td>
     <td></td>
     <td>X</td>
@@ -805,9 +1019,19 @@ The following table describes which actions a WIPP user can do depending on thei
     <td><b>U</b></td>
     <td><b>D</b></td>
     <td><b></b></td>
+    <td><b>C</b></td>
+    <td><b>R</b></td>
+    <td><b>U</b></td>
+    <td><b>D</b></td>
+    <td><b></b></td>
   </tr>
   <tr>
     <td><i>Private (is owner)</i></td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>Y</td>
+    <td>Y</td>
+    <td></td>
     <td>Y</td>
     <td>Y</td>
     <td>Y</td>
@@ -841,6 +1065,11 @@ The following table describes which actions a WIPP user can do depending on thei
     <td>N</td>
     <td>N</td>
     <td></td>
+    <td>X</td>
+    <td>N</td>
+    <td>N</td>
+    <td>N</td>
+    <td></td>
   </tr>
   <tr>
     <td><i>Public (not owner)</i></td>
@@ -848,6 +1077,11 @@ The following table describes which actions a WIPP user can do depending on thei
     <td>Y</td>
     <td>Y</td>
     <td>Y</td>
+    <td></td>
+    <td>X</td>
+    <td>Y</td>
+    <td>N</td>
+    <td>N</td>
     <td></td>
     <td>X</td>
     <td>Y</td>

--- a/docs/auth-acl/realm-export.json
+++ b/docs/auth-acl/realm-export.json
@@ -61,6 +61,15 @@
         "attributes": {}
       },
       {
+        "id": "75ce82cb-04a4-4061-a1e1-4fb83ee211c0",
+        "name": "developer",
+        "description": "WIPP developer - can manage plugins",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "WIPPKeycloak",
+        "attributes": {}
+      },
+      {
         "id": "c482e1dc-9cf9-4ad8-b2f0-110551c83a2d",
         "name": "user",
         "description": "WIPP user",
@@ -750,11 +759,13 @@
       "clientAuthenticatorType": "client-secret",
       "secret": "**********",
       "redirectUris": [
+        "http://localhost:8080/api/swagger-ui/oauth2-redirect.html",
         "http://localhost:4200/*",
         "https://localhost:4200/*"
       ],
       "webOrigins": [
         "https://localhost:4200",
+        "http://localhost:8080",
         "http://localhost:4200"
       ],
       "notBefore": 0,

--- a/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/plugin/PluginRepositoryRestTest.java
+++ b/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/plugin/PluginRepositoryRestTest.java
@@ -1,0 +1,232 @@
+package gov.nist.itl.ssd.wipp.backend.argo.workflows.plugin;
+
+import gov.nist.itl.ssd.wipp.backend.Application;
+import gov.nist.itl.ssd.wipp.backend.app.SecurityConfig;
+import gov.nist.itl.ssd.wipp.backend.data.imagescollection.ImagesCollection;
+import gov.nist.itl.ssd.wipp.backend.data.imagescollection.ImagesCollectionRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
+/**
+ * <h1>Collection of tests for {@link PluginRepository}</h1>
+ * <p>
+ * Testing access control on CREATE, UPDATE, DELETE operations for
+ * {@link PluginRepository} with REST access
+ * <p>
+ * Default supported HTTP methods for Spring Data REST repositories are:
+ * <ul>
+ * 	<li>GET and POST for the Collection Resource (/{collectionName})</li>
+ * 	<li>GET, PUT, PATCH and DELETE for the Item Resource (/{collectionName}/{itemId})</li>
+ * 	<li>GET for the Search Resource (/{collectionName}/search/findBy...)</li>
+ * </ul>
+ * Uses embedded MongoDB database and mock Keycloak users
+ *
+ * @author Mylene Simon <mylene.simon at nist.gov>
+ *
+ */
+@RunWith(SpringRunner.class)
+@ContextConfiguration
+@SpringBootTest(classes = { Application.class, SecurityConfig.class },
+        properties = { "spring.data.mongodb.port=0" })
+public class PluginRepositoryRestTest {
+
+    static final String PAYLOAD = "{\"name\": \"org/test-plugin\", \"version\": \"2.0.0\"}";
+
+    @Autowired
+    WebApplicationContext context;
+
+    MockMvc mvc;
+
+    @Autowired
+    PluginRepository pluginRepository;
+
+    Plugin plugin;
+
+    @Before
+    public void setUp() {
+        mvc = webAppContextSetup(context)
+                .apply(springSecurity())
+                .build();
+
+        // Clear embedded database
+        pluginRepository.deleteAll();
+
+        // Create and save test plugin
+        plugin = new Plugin();
+        plugin.setName("org/test-plugin");
+        plugin.setVersion("1.0.0");
+        pluginRepository.save(plugin);
+    }
+
+    @Test
+    @WithAnonymousUser
+    public void rejectsPostRequestsToPluginResourceForAnonymousUser() throws Exception {
+
+        mvc.perform(post("/api/plugins")
+                        .content(PAYLOAD)
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles={"user"})
+    public void rejectsPostRequestsToPluginResourceForUser() throws Exception {
+
+        mvc.perform(post("/api/plugins")
+                        .content(PAYLOAD)
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles={"admin"})
+    public void acceptsPostRequestsToPluginResourceForAdmin() throws Exception {
+
+        mvc.perform(post("/api/plugins")
+                        .content(PAYLOAD)
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @WithMockUser(roles={"developer"})
+    public void acceptsPostRequestsToPluginResourceForDeveloper() throws Exception {
+
+        mvc.perform(post("/api/plugins")
+                        .content(PAYLOAD)
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    @WithAnonymousUser
+    public void rejectsPatchRequestsToPluginResourceForAnonymousUser() throws Exception {
+
+        mvc.perform(patch("/api/plugins/" + plugin.getId())
+                        .content(PAYLOAD)
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles={"user"})
+    public void rejectsPatchRequestsToPluginResourceForUser() throws Exception {
+
+        mvc.perform(patch("/api/plugins/" + plugin.getId())
+                        .content(PAYLOAD)
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles={"admin"})
+    public void acceptsPatchRequestsToPluginResourceForAdmin() throws Exception {
+
+        mvc.perform(patch("/api/plugins/" + plugin.getId())
+                        .content(PAYLOAD)
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(roles={"developer"})
+    public void acceptsPatchRequestsToPluginResourceForDeveloper() throws Exception {
+
+        mvc.perform(patch("/api/plugins/" + plugin.getId())
+                        .content(PAYLOAD)
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithAnonymousUser
+    public void rejectsPutRequestsToPluginResourceForAnonymousUser() throws Exception {
+
+        mvc.perform(put("/api/plugins/" + plugin.getId())
+                        .content(PAYLOAD)
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles={"user"})
+    public void rejectsPutRequestsToPluginResourceForUser() throws Exception {
+
+        mvc.perform(put("/api/plugins/" + plugin.getId())
+                        .content(PAYLOAD)
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles={"admin"})
+    public void acceptsPutRequestsToPluginResourceForAdmin() throws Exception {
+
+        mvc.perform(put("/api/plugins/" + plugin.getId())
+                        .content(PAYLOAD)
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(roles={"developer"})
+    public void acceptsPutRequestsToPluginResourceForDeveloper() throws Exception {
+
+        mvc.perform(put("/api/plugins/" + plugin.getId())
+                        .content(PAYLOAD)
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithAnonymousUser
+    public void rejectsDeleteRequestsToPluginResourceForAnonymousUser() throws Exception {
+
+        mvc.perform(delete("/api/plugins/" + plugin.getId())
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles={"user"})
+    public void rejectsDeleteRequestsToPluginResourceForUser() throws Exception {
+
+        mvc.perform(delete("/api/plugins/" + plugin.getId())
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @WithMockUser(roles={"admin"})
+    public void acceptsDeleteRequestsToPluginResourceForAdmin() throws Exception {
+
+        mvc.perform(delete("/api/plugins/" + plugin.getId())
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(roles={"developer"})
+    public void acceptsDeleteRequestsToPluginResourceForDeveloper() throws Exception {
+
+        mvc.perform(delete("/api/plugins/" + plugin.getId())
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isNoContent());
+    }
+
+}

--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/plugin/PluginEventHandler.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/plugin/PluginEventHandler.java
@@ -24,7 +24,8 @@ import gov.nist.itl.ssd.wipp.backend.core.rest.exception.NotFoundException;
 
 /**
  * Plugin Repository Event Handler
- * All creation/modification/deletion actions via REST are restricted to admin users
+ * All creation/modification/deletion actions via REST are restricted to
+ * users with role 'admin' or 'developer'
  * 
  * @author Mylene Simon <mylene.simon at nist.gov>
  *
@@ -37,13 +38,13 @@ public class PluginEventHandler {
 	PluginRepository pluginRepository;
 	
     @HandleBeforeCreate
-	@PreAuthorize("hasRole('admin')")
+	@PreAuthorize("hasRole('admin') or hasRole('developer')")
     public void handleBeforeCreate(Plugin plugin) {
         // TODO: Plugin JSON validation against schema
     }
 
     @HandleBeforeSave
-    @PreAuthorize("hasRole('admin')")
+    @PreAuthorize("hasRole('admin') or hasRole('developer')")
     public void handleBeforeSave(Plugin plugin) {
         Optional<Plugin> result = pluginRepository.findById(
                 plugin.getId());
@@ -53,7 +54,7 @@ public class PluginEventHandler {
     }
 
     @HandleBeforeDelete
-    @PreAuthorize("hasRole('admin')")
+    @PreAuthorize("hasRole('admin') or hasRole('developer')")
     public void handleBeforeDelete(Plugin plugin) {
     	Optional<Plugin> result = pluginRepository.findById(
                 plugin.getId());


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Add access control for new role *developer*:
- has all permissions a regular *user* has
- can create, modify and delete plugins

## Adding the new role in Keycloak

WIPP Keycloak realm has been updated, but the new role can also be added from the Keycloak admin interface following these instructions:
- log in to the Keycloak admin dashboard using the admin username and password (usually set during deployment)
- from the WIPP realm, click on the left on "Roles" (under "Configure") then "Add role"
- fill in information: 
  - Role Name: developer
  - Description: WIPP developer - can manage plugins
- click on "Save"

To assign the role to users:
- click on the left on "Users" (under "Manage") then "View all users" (or search for a specific one)
- click on "Edit" then "Role Mappings"
- select "developer" and "Add selected"