### PR TITLE
feat: plugin hardware requirements

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+ #!/usr/bin/env bash
 
 export $(egrep -v '^#' .env)
 
@@ -19,6 +19,7 @@ sed -i.bak \
     -e "s|TOLERATIONS_VALUE|${TOLERATIONS}|g" \
     -e "s|OME_CONVERTER_THREADS_VALUE|${OME_CONVERTER_THREADS}|g" \
     -e "s|KEYCLOAK_AUTH_URL_VALUE|${KEYCLOAK_AUTH_URL}|g" \
+    -e "s|WORKFLOW_PLUGINHARDWAREREQUIREMENTS_ENABLED_VALUE|${WORKFLOW_PLUGINHARDWAREREQUIREMENTS_ENABLED}|g" \
     deploy/kubernetes/backend-deployment.yaml
 rm deploy/kubernetes/backend-deployment.yaml.bak
 

--- a/deploy/docker/application.properties
+++ b/deploy/docker/application.properties
@@ -17,6 +17,7 @@ workflow.binary=argo
 storage.workflows=/data/WIPP-plugins/workflows
 workflow.nodeSelector=@workflow_nodeSelector@
 workflow.tolerations=@workflow_tolerations@
+workflow.pluginHardwareRequirements.enabled=false
 
 # Job storage configuration
 storage.temp.jobs=/data/WIPP-plugins/temp/jobs

--- a/deploy/kubernetes/backend-deployment.yaml
+++ b/deploy/kubernetes/backend-deployment.yaml
@@ -65,6 +65,8 @@ spec:
               value: OME_CONVERTER_THREADS_VALUE
             - name: KEYCLOAK_AUTH_URL
               value: KEYCLOAK_AUTH_URL_VALUE
+            - name: WORKFLOW_PLUGINHARDWAREREQUIREMENTS_ENABLED
+              value: WORKFLOW_PLUGINHARDWAREREQUIREMENTS_ENABLED_VALUE
           volumeMounts:
             - mountPath: /data/WIPP-plugins
               name: data

--- a/sample-env
+++ b/sample-env
@@ -7,6 +7,7 @@ STORAGE_MONGO=<pvc storage size>
 ELASTIC_APM_URL=<url to Elastic APM>
 NODE_SELECTOR=<node selector in the format "key1:value1;key2:value2;">
 TOLERATIONS=<pod tolerations in the format "key1:operator1:value1:effect1;", optional values can be skipped "key1:operator1::;">
+WORKFLOW_PLUGINHARDWAREREQUIREMENTS_ENABLED=<true/false>
 
 OME_CONVERTER_THREADS=<number of concurrent threads for image conversion, default is 6>
 KEYCLOAK_AUTH_URL=<url to keycloak>

--- a/wipp-backend-application/pom.xml
+++ b/wipp-backend-application/pom.xml
@@ -66,6 +66,7 @@
 				<mongodb.database>wipp-plugins</mongodb.database>
 				<workflow.management.system>argo</workflow.management.system>
 				<workflow.binary>argo</workflow.binary>
+				<workflow.pluginHardwareRequirements.enabled>false</workflow.pluginHardwareRequirements.enabled>
 				<kube.wippdata.pvc>wippdata-pvc</kube.wippdata.pvc>
 				<storage.root>${user.home}/WIPP-plugins</storage.root>
 				<storage.workflows>${user.home}/WIPP-plugins/workflows</storage.workflows>
@@ -95,6 +96,7 @@
 				<mongodb.database>wipp-plugins</mongodb.database>
 				<workflow.management.system>argo</workflow.management.system>
 				<workflow.binary>argo</workflow.binary>
+				<workflow.pluginHardwareRequirements.enabled>false</workflow.pluginHardwareRequirements.enabled>
 				<kube.wippdata.pvc>wippdata-pvc</kube.wippdata.pvc>
 				<storage.root>/data/WIPP-plugins</storage.root>
 				<storage.workflows>/data/WIPP-plugins/workflows</storage.workflows>

--- a/wipp-backend-application/src/main/resources/application.properties
+++ b/wipp-backend-application/src/main/resources/application.properties
@@ -17,6 +17,7 @@ workflow.binary=@workflow.binary@
 storage.workflows=@storage.workflows@
 workflow.nodeSelector=@workflow.nodeSelector@
 workflow.tolerations=@workflow.tolerations@
+workflow.pluginHardwareRequirements.enabled=@workflow.pluginHardwareRequirements.enabled@
 
 # Kubernetes PVC name for WIPP Data volume
 kube.wippdata.pvc=@kube.wippdata.pvc@

--- a/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/plugin/PluginRepositoryRestTest.java
+++ b/wipp-backend-application/src/test/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/plugin/PluginRepositoryRestTest.java
@@ -2,8 +2,8 @@ package gov.nist.itl.ssd.wipp.backend.argo.workflows.plugin;
 
 import gov.nist.itl.ssd.wipp.backend.Application;
 import gov.nist.itl.ssd.wipp.backend.app.SecurityConfig;
-import gov.nist.itl.ssd.wipp.backend.data.imagescollection.ImagesCollection;
-import gov.nist.itl.ssd.wipp.backend.data.imagescollection.ImagesCollectionRepository;
+import gov.nist.itl.ssd.wipp.backend.core.model.computation.Plugin;
+import gov.nist.itl.ssd.wipp.backend.core.model.computation.PluginRepository;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/job/ArgoJobUtilsService.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/job/ArgoJobUtilsService.java
@@ -18,9 +18,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
-import gov.nist.itl.ssd.wipp.backend.argo.workflows.plugin.Plugin;
-import gov.nist.itl.ssd.wipp.backend.argo.workflows.plugin.PluginIO;
-import gov.nist.itl.ssd.wipp.backend.argo.workflows.plugin.PluginRepository;
+import gov.nist.itl.ssd.wipp.backend.core.model.computation.Plugin;
+import gov.nist.itl.ssd.wipp.backend.core.model.computation.PluginIO;
+import gov.nist.itl.ssd.wipp.backend.core.model.computation.PluginRepository;
 import gov.nist.itl.ssd.wipp.backend.core.model.data.DataHandler;
 import gov.nist.itl.ssd.wipp.backend.core.model.data.DataHandlerService;
 import gov.nist.itl.ssd.wipp.backend.core.model.job.Job;

--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/spec/ArgoTemplatePlugin.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/spec/ArgoTemplatePlugin.java
@@ -1,11 +1,16 @@
 package gov.nist.itl.ssd.wipp.backend.argo.workflows.spec;
 
+import gov.nist.itl.ssd.wipp.backend.core.model.computation.PluginResourceRequirements;
+
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class ArgoTemplatePlugin extends ArgoAbstractTemplate {
     private Map<String, List<NameValueParam>> inputs;
     private ArgoTemplatePluginContainer container;
+
+    private Map<String, String> nodeSelector;
 
     public Map<String, List<NameValueParam>> getInputs() {
         return inputs;
@@ -21,5 +26,30 @@ public class ArgoTemplatePlugin extends ArgoAbstractTemplate {
 
     public void setContainer(ArgoTemplatePluginContainer container) {
         this.container = container;
+    }
+
+    public Map<String, String> getNodeSelector() {
+        return nodeSelector;
+    }
+
+    public void setNodeSelector(Map<String, String> nodeSelector) {
+        this.nodeSelector = nodeSelector;
+    }
+
+    public void setNodeSelector(PluginResourceRequirements pluginResourceRequirements) {
+        if (pluginResourceRequirements != null) {
+            Map<String, String> selectors = new HashMap<>();
+            // add CPU-related selectors
+            if (pluginResourceRequirements.isCpuAVX()) {
+                selectors.put("feature.node.kubernetes.io/cpu-cpuid.AVX", "true");
+            }
+            if (pluginResourceRequirements.isCpuAVX2()) {
+                selectors.put("feature.node.kubernetes.io/cpu-cpuid.AVX2", "true");
+            }
+
+            if (!selectors.isEmpty()) {
+                this.nodeSelector = selectors;
+            }
+        }
     }
 }

--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/spec/ArgoTemplatePluginContainer.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/spec/ArgoTemplatePluginContainer.java
@@ -9,6 +9,8 @@ public class ArgoTemplatePluginContainer {
     private List<String> args;
     private List<Map<String, Object>> volumeMounts;
 
+    private ArgoTemplatePluginContainerResources resources;
+
     public String getImage() {
         return image;
     }
@@ -39,5 +41,13 @@ public class ArgoTemplatePluginContainer {
 
     public void setVolumeMounts(List<Map<String, Object>> volumeMounts) {
         this.volumeMounts = volumeMounts;
+    }
+
+    public ArgoTemplatePluginContainerResources getResources() {
+        return resources;
+    }
+
+    public void setResources(ArgoTemplatePluginContainerResources resources) {
+        this.resources = resources;
     }
 }

--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/spec/ArgoTemplatePluginContainerResources.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/spec/ArgoTemplatePluginContainerResources.java
@@ -1,0 +1,64 @@
+package gov.nist.itl.ssd.wipp.backend.argo.workflows.spec;
+
+import gov.nist.itl.ssd.wipp.backend.core.model.computation.PluginResourceRequirements;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ArgoTemplatePluginContainerResources {
+
+    private Map<String, String> requests;
+
+    private Map<String, String> limits;
+
+    public ArgoTemplatePluginContainerResources(PluginResourceRequirements resourceRequirements) {
+        if (resourceRequirements != null) {
+            this.generateContainerResourceRequests(resourceRequirements);
+            this.generateContainerResourceLimits(resourceRequirements);
+        }
+    }
+
+    public Map<String, String> getRequests() {
+        return requests;
+    }
+
+    public void setRequests(Map<String, String> requests) {
+        this.requests = requests;
+    }
+
+    public Map<String, String> getLimits() {
+        return limits;
+    }
+
+    public void setLimits(Map<String, String> limits) {
+        this.limits = limits;
+    }
+
+    private void generateContainerResourceRequests(PluginResourceRequirements pluginResourceRequirements) {
+        Map<String, String> requests = new HashMap<>();
+
+        if (pluginResourceRequirements.getCoresMin() != null) {
+            requests.put("cpu", String.valueOf(pluginResourceRequirements.getCoresMin()));
+        }
+        if (pluginResourceRequirements.getRamMin() != null) {
+            requests.put("memory", String.valueOf(pluginResourceRequirements.getRamMin()) + "Mi");
+        }
+
+        if(!requests.isEmpty()) {
+            this.requests = requests;
+        }
+    }
+
+    private void generateContainerResourceLimits(PluginResourceRequirements pluginResourceRequirements) {
+        Map<String, String> limits = new HashMap<>();
+
+        if (pluginResourceRequirements.isGpu()) {
+            limits.put("nvidia.com/gpu", "1");
+        }
+
+        if (!limits.isEmpty()) {
+            this.limits = limits;
+        }
+    }
+
+}

--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowExitController.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowExitController.java
@@ -11,9 +11,9 @@
  */
 package gov.nist.itl.ssd.wipp.backend.argo.workflows.workflow;
 
-import gov.nist.itl.ssd.wipp.backend.argo.workflows.plugin.Plugin;
-import gov.nist.itl.ssd.wipp.backend.argo.workflows.plugin.PluginIO;
-import gov.nist.itl.ssd.wipp.backend.argo.workflows.plugin.PluginRepository;
+import gov.nist.itl.ssd.wipp.backend.core.model.computation.Plugin;
+import gov.nist.itl.ssd.wipp.backend.core.model.computation.PluginIO;
+import gov.nist.itl.ssd.wipp.backend.core.model.computation.PluginRepository;
 import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
 import gov.nist.itl.ssd.wipp.backend.core.model.data.DataHandler;
 import gov.nist.itl.ssd.wipp.backend.core.model.data.DataHandlerService;

--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowSubmitController.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowSubmitController.java
@@ -1,7 +1,7 @@
 package gov.nist.itl.ssd.wipp.backend.argo.workflows.workflow;
 
-import gov.nist.itl.ssd.wipp.backend.argo.workflows.plugin.Plugin;
-import gov.nist.itl.ssd.wipp.backend.argo.workflows.plugin.PluginRepository;
+import gov.nist.itl.ssd.wipp.backend.core.model.computation.Plugin;
+import gov.nist.itl.ssd.wipp.backend.core.model.computation.PluginRepository;
 import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
 import gov.nist.itl.ssd.wipp.backend.core.model.job.Job;
 import gov.nist.itl.ssd.wipp.backend.core.model.job.JobRepository;
@@ -14,7 +14,6 @@ import io.swagger.annotations.Api;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PostAuthorize;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/CoreConfig.java
+++ b/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/CoreConfig.java
@@ -49,6 +49,9 @@ public class CoreConfig {
 
     @Value("${workflow.tolerations}")
     private String workflowTolerations;
+
+    @Value("${workflow.pluginHardwareRequirements.enabled}")
+    private boolean workflowPluginHardwareRequirementsEnabled;
     
     @Value("${kube.wippdata.pvc}")
     private String wippDataPVCName;
@@ -183,6 +186,10 @@ public class CoreConfig {
 
     public String getWorkflowTolerations() {
         return workflowTolerations;
+    }
+
+    public boolean isWorkflowPluginHardwareRequirementsEnabled() {
+        return workflowPluginHardwareRequirementsEnabled;
     }
 
 	public String getWippDataPVCName() {

--- a/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/model/computation/Plugin.java
+++ b/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/model/computation/Plugin.java
@@ -1,6 +1,16 @@
-package gov.nist.itl.ssd.wipp.backend.argo.workflows.plugin;
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.core.model.computation;
 
-import gov.nist.itl.ssd.wipp.backend.core.model.computation.Computation;
 import gov.nist.itl.ssd.wipp.backend.core.rest.annotation.IdExposed;
 
 import java.util.List;
@@ -27,6 +37,9 @@ public class Plugin extends Computation {
 
     private List<PluginIO> inputs;
     private List<PluginIO> outputs;
+
+    private PluginResourceRequirements resourceRequirements;
+
     private List<Object> ui;  // TODO describe parameter so as not to use Object
 
     public String getContainerId() {
@@ -115,6 +128,14 @@ public class Plugin extends Computation {
 
     public void setOutputs(List<PluginIO> outputs) {
         this.outputs = outputs;
+    }
+
+    public PluginResourceRequirements getResourceRequirements() {
+        return resourceRequirements;
+    }
+
+    public void setResourceRequirements(PluginResourceRequirements resourceRequirements) {
+        this.resourceRequirements = resourceRequirements;
     }
 
     public List<Object> getUi() {

--- a/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/model/computation/PluginEventHandler.java
+++ b/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/model/computation/PluginEventHandler.java
@@ -9,7 +9,7 @@
  * any other characteristic. We would appreciate acknowledgement if the
  * software is used.
  */
-package gov.nist.itl.ssd.wipp.backend.argo.workflows.plugin;
+package gov.nist.itl.ssd.wipp.backend.core.model.computation;
 
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/model/computation/PluginIO.java
+++ b/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/model/computation/PluginIO.java
@@ -1,4 +1,15 @@
-package gov.nist.itl.ssd.wipp.backend.argo.workflows.plugin;
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.core.model.computation;
 
 import java.util.Map;
 

--- a/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/model/computation/PluginRepository.java
+++ b/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/model/computation/PluginRepository.java
@@ -1,4 +1,15 @@
-package gov.nist.itl.ssd.wipp.backend.argo.workflows.plugin;
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.core.model.computation;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -8,7 +19,6 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 import java.util.List;
-
 
 /**
  *

--- a/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/model/computation/PluginResourceCudaRequirements.java
+++ b/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/model/computation/PluginResourceCudaRequirements.java
@@ -1,0 +1,40 @@
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.core.model.computation;
+
+/**
+ * GPU-related resource requirements for the plugin
+ *
+ * @author Mylene Simon <mylene.simon at nist.gov>
+ */
+public class PluginResourceCudaRequirements {
+
+    Long deviceMemoryMin;
+    Object cudaComputeCapability;
+
+    public Long getDeviceMemoryMin() {
+        return deviceMemoryMin;
+    }
+
+    public void setDeviceMemoryMin(Long deviceMemoryMin) {
+        this.deviceMemoryMin = deviceMemoryMin;
+    }
+
+    public Object getCudaComputeCapability() {
+        return cudaComputeCapability;
+    }
+
+    public void setCudaComputeCapability(Object cudaComputeCapability) {
+        this.cudaComputeCapability = cudaComputeCapability;
+    }
+
+}

--- a/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/model/computation/PluginResourceRequirements.java
+++ b/wipp-backend-core/src/main/java/gov/nist/itl/ssd/wipp/backend/core/model/computation/PluginResourceRequirements.java
@@ -1,0 +1,87 @@
+/*
+ * This software was developed at the National Institute of Standards and
+ * Technology by employees of the Federal Government in the course of
+ * their official duties. Pursuant to title 17 Section 105 of the United
+ * States Code this software is not subject to copyright protection and is
+ * in the public domain. This software is an experimental system. NIST assumes
+ * no responsibility whatsoever for its use by other parties, and makes no
+ * guarantees, expressed or implied, about its quality, reliability, or
+ * any other characteristic. We would appreciate acknowledgement if the
+ * software is used.
+ */
+package gov.nist.itl.ssd.wipp.backend.core.model.computation;
+
+/**
+ * Hardware resource requirements for the plugin
+ *
+ * @author Mylene Simon <mylene.simon at nist.gov>
+ */
+public class PluginResourceRequirements {
+
+    // Minimum RAM in mebibytes (Mi)
+    Long ramMin;
+
+    // Minimum number of CPU cores
+    Long coresMin;
+
+    // Advanced Vector Extensions (AVX) CPU capability required
+    boolean cpuAVX = false;
+
+    // Advanced Vector Extensions 2 (AVX2) CPU capability required
+    boolean cpuAVX2 = false;
+
+    // GPU/accelerator required
+    boolean gpu = false;
+
+    // GPU Cuda-related requirements
+    PluginResourceCudaRequirements cudaRequirements;
+
+    public Long getRamMin() {
+        return ramMin;
+    }
+
+    public void setRamMin(Long ramMin) {
+        this.ramMin = ramMin;
+    }
+
+    public Long getCoresMin() {
+        return coresMin;
+    }
+
+    public void setCoresMin(Long coresMin) {
+        this.coresMin = coresMin;
+    }
+
+    public boolean isCpuAVX() {
+        return cpuAVX;
+    }
+
+    public void setCpuAVX(boolean cpuAVX) {
+        this.cpuAVX = cpuAVX;
+    }
+
+    public boolean isCpuAVX2() {
+        return cpuAVX2;
+    }
+
+    public void setCpuAVX2(boolean cpuAVX2) {
+        this.cpuAVX2 = cpuAVX2;
+    }
+
+    public boolean isGpu() {
+        return gpu;
+    }
+
+    public void setGpu(boolean gpu) {
+        this.gpu = gpu;
+    }
+
+    public PluginResourceCudaRequirements getCudaRequirements() {
+        return cudaRequirements;
+    }
+
+    public void setCudaRequirements(PluginResourceCudaRequirements cudaRequirements) {
+        this.cudaRequirements = cudaRequirements;
+    }
+}
+


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

Initial implementation for plugin hardware/resource requirements support.

Example of `resourceRequirements` in plugin manifest:
```json
"resourceRequirements": {
    "ramMin": 2048,
    "coresMin": 1,
    "cpuAVX": true,
    "cpuAVX2": false,
    "gpu": true,
    "cudaRequirements": {
      "deviceMemoryMin": 100,
     "cudaComputeCapability": "8.0"
    }
}
```

See update of the WIPP plugin JSON manifest schema for more details: https://github.com/usnistgov/WIPP-Plugins-base-templates/commit/bb792dca5a5f84080b2b1808ea2cfa4deb3e95f1

In Argo Workflows, this will be translated to a mix of `nodeSelector` (at the workflow step level) and `limits`/`requests` (at the workflow step container level), for example:
```yaml
---
apiVersion: "argoproj.io/v1alpha1"
kind: "Workflow"
metadata:
  generateName: "plugin-req-test-"
spec:
  entrypoint: "workflow"
  onExit: "exit-handler"
  nodeSelector: {}
  tolerations: []
  templates:
  - name: "thresholding-plugin---requirements-1-0-0-req-62e20c87e7710c04ba2eb6e7"
    inputs:
      ...
    container:
      ...
      resources:
        requests:
          memory: "2048Mi"
          cpu: "1"
        limits:
          nvidia.com/gpu: "1"
    nodeSelector:
      feature.node.kubernetes.io/cpu-cpuid.AVX: "true"
  - name: "workflow"
    dag:
      tasks:
      - name: "plugin-req-test-thresh"
        template: "thresholding-plugin---requirements-1-0-0-req-62e20c87e7710c04ba2eb6e7"
        dependencies: []
        ...
  ...
```
For Argo/Kubernetes, WIPP Backend relies on node labels provided by the [Node Feature Discovery](https://github.com/kubernetes-sigs/node-feature-discovery) and [Nvidia GPU Feature Discovery](https://github.com/NVIDIA/gpu-feature-discovery).

Cuda-specific requirements are currently ignored and will be supported in a second PR.

**Enable/disable resource requirements**
The hardware requirements support in the WIPP Backend can be enabled or disabled using the `workflow.pluginHardwareRequirements.enabled` app property (`false` by default).
The value can be set in the `pom.xml` file (preferred for `dev` mode) or via the `env` variable `WORKFLOW_PLUGINHARDWAREREQUIREMENTS_ENABLED` (Kubernetes/prod mode).

## Related issues

https://github.com/usnistgov/WIPP/issues/27