### PR TITLE
feat: ome tiff pyramid conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,9 @@ RUN wget https://github.com/argoproj/argo-workflows/releases/download/${ARGO_VER
     chmod +x argo-linux-amd64 && \
     mv argo-linux-amd64 /usr/local/bin/argo
 
+# Install blosc for Zarr compression
+RUN apk add --no-cache blosc
+
 # Copy WIPP backend application exec WAR
 COPY --from=builder ${EXEC_DIR}/${BACKEND_NAME}/target/${BACKEND_NAME}-*-exec.war ${EXEC_DIR}/wipp-backend.war
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ Default root folder configuration for the local backend import of images collect
 This default configuration can be changed in `wipp-backend-application/pom.xml` (property `storage.local.import`) when running locally or in the deployment 
 manifest when running in a Kubernetes cluster (an additional volume needs to be mounted if the new location is not in the WIPP root data folder).
 
+### Data conversion
+* WIPP uses the [bioformats2raw](https://github.com/glencoesoftware/bioformats2raw) and [raw2ometiff](https://github.com/glencoesoftware/raw2ometiff) converters 
+to convert images to tiled pyramidal OME TIFF format, which require Blosc to be installed:
+  * https://github.com/Blosc/c-blosc for compilation and installation instructions
+
 ## Compiling
 ```shell
 mvn clean install

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -36,4 +36,6 @@ if [[ -n ${ELASTIC_APM_SERVER_URLS} && -n ${ELASTIC_APM_SERVICE_NAME} ]]; then
   export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -Delastic.apm.server_urls=$ELASTIC_APM_SERVER_URLS"
 fi
 
+keytool -importcert -file /etc/ssl/certs/tls.crt -noprompt -alias certificate_alias -storepass changeit -keystore $JAVA_HOME/lib/security/cacerts
+
 java -jar /opt/wipp/wipp-backend.war

--- a/wipp-backend-application/src/main/java/gov/nist/itl/ssd/wipp/backend/app/OpenApiConfig.java
+++ b/wipp-backend-application/src/main/java/gov/nist/itl/ssd/wipp/backend/app/OpenApiConfig.java
@@ -3,10 +3,7 @@ package gov.nist.itl.ssd.wipp.backend.app;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
-import io.swagger.v3.oas.annotations.security.OAuthFlow;
-import io.swagger.v3.oas.annotations.security.OAuthFlows;
-import io.swagger.v3.oas.annotations.security.OAuthScope;
-import io.swagger.v3.oas.annotations.security.SecurityScheme;
+import io.swagger.v3.oas.annotations.security.*;
 
 /**
  * OpenAPI docs configuration
@@ -14,7 +11,8 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme;
  * @author Mylene Simon <mylene.simon at nist.gov>
  */
 @OpenAPIDefinition(info = @Info(title = "WIPP",
-        description = "WIPP REST API", version = "v3.2.0"))
+        description = "WIPP REST API", version = "v3.2.0"),
+        security = @SecurityRequirement(name = "security_auth"))
 @SecurityScheme(name = "security_auth", type = SecuritySchemeType.OAUTH2,
         flows = @OAuthFlows(authorizationCode = @OAuthFlow(
                 authorizationUrl = "${springdoc.oAuthFlow.authorizationUrl}"
@@ -22,3 +20,4 @@ import io.swagger.v3.oas.annotations.security.SecurityScheme;
                 @OAuthScope(name = "openid", description = "Keycloak") })))
 public class OpenApiConfig {
 }
+

--- a/wipp-backend-application/src/main/java/gov/nist/itl/ssd/wipp/backend/app/SecurityConfig.java
+++ b/wipp-backend-application/src/main/java/gov/nist/itl/ssd/wipp/backend/app/SecurityConfig.java
@@ -84,9 +84,10 @@ public class SecurityConfig
 				.requestMatchers(HttpMethod.PUT).authenticated()
 				.requestMatchers(HttpMethod.PATCH).authenticated()
 				.requestMatchers(HttpMethod.DELETE).authenticated()
+				// temporary disabled
 				// restrict wdzt pyramid files access to users authorized to access the pyramid
-				.requestMatchers(CoreConfig.PYRAMIDS_BASE_URI + "/{pyramidId}/**")
-					.access(new WebExpressionAuthorizationManager("hasRole('admin') or @pyramidSecurity.checkAuthorize(#pyramidId, false)"))
+//				.requestMatchers(CoreConfig.PYRAMIDS_BASE_URI + "/{pyramidId}/**")
+//					.access(new WebExpressionAuthorizationManager("hasRole('admin') or @pyramidSecurity.checkAuthorize(#pyramidId, false)"))
 				// allow other GET/OPTIONS requests, fine grain access control done at method level
 				.anyRequest().permitAll()
 		);

--- a/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowSubmitController.java
+++ b/wipp-backend-argo-workflows/src/main/java/gov/nist/itl/ssd/wipp/backend/argo/workflows/workflow/WorkflowSubmitController.java
@@ -62,8 +62,8 @@ public class WorkflowSubmitController {
         produces = { "application/hal+json" }
     )
     public EntityModel<Workflow> submit(
-        @PathVariable("workflowId") String workflowId,
-        final PersistentEntityResourceAssembler assembler
+        @PathVariable("workflowId") String workflowId
+        //final PersistentEntityResourceAssembler assembler
     ) {
         // Retrieve Workflow object
         Optional<Workflow> wippWorkflow = workflowRepository.findById(

--- a/wipp-backend-data/pom.xml
+++ b/wipp-backend-data/pom.xml
@@ -25,6 +25,10 @@
 			<id>ome.snapshots</id>
 			<url>https://artifacts.openmicroscopy.org/artifactory/ome.snapshots</url>
 		</repository>
+		<repository>
+			<id>bioformats2raw2ometiff</id>
+			<url>https://repo.glencoesoftware.com/repository/bioformats2raw2ometiff</url>
+		</repository>
 	</repositories>
 
 	<dependencies>
@@ -40,6 +44,24 @@
 			<artifactId>formats-gpl</artifactId>
 			<version>7.2.0</version>
 			<scope>compile</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.glencoesoftware</groupId>
+			<artifactId>raw2ometiff</artifactId>
+			<version>0.7.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.glencoesoftware</groupId>
+			<artifactId>bioformats2raw</artifactId>
+			<version>0.9.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>info.picocli</groupId>
+			<artifactId>picocli</artifactId>
+			<version>4.7.5</version>
 		</dependency>
 
 		<dependency>

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/ImagesCollection.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/ImagesCollection.java
@@ -28,7 +28,8 @@ import java.util.Date;
 /**
  *
  * @author Antoine Vandecreme <antoine.vandecreme at nist.gov>
- * Adapted by Mohamed Ouladi <mohamed.ouladi@nist.gov>
+ * @author Mohamed Ouladi <mohamed.ouladi at nist.gov>
+ * @author Mylene Simon <mylene.simon at nist.gov>
  */
 @IdExposed
 @Document
@@ -53,6 +54,8 @@ public class ImagesCollection extends Data {
     private String sourceBackendImport;
     
     private ImagesCollectionImportMethod importMethod;
+
+    private ImagesCollectionFormat format;
 
     private boolean locked;
 
@@ -83,30 +86,43 @@ public class ImagesCollection extends Data {
     }
 
     public ImagesCollection(String name) {
-        this(name, false, ImagesCollectionImportMethod.UPLOADED);
+        this(name, false, ImagesCollectionImportMethod.UPLOADED, ImagesCollectionFormat.OMETIFF);
     }
-    
-    public ImagesCollection(String name, boolean locked, ImagesCollectionImportMethod importMethod){
+
+    public ImagesCollection(String name, ImagesCollectionFormat format) {
+        this(name, false, ImagesCollectionImportMethod.UPLOADED, format);
+    }
+
+    public ImagesCollection(String name, boolean locked, ImagesCollectionImportMethod importMethod, ImagesCollectionFormat format){
         this.name = name;
         this.locked = locked;
         this.creationDate = new Date();	
         this.importMethod = importMethod;
+        this.format = format;
     }
 
     public ImagesCollection(Job job, String outputName) {
+        this(job, outputName, ImagesCollectionFormat.OMETIFF);
+    }
+    public ImagesCollection(Job job, String outputName, ImagesCollectionFormat format) {
         this.name = job.getName() + "-" + outputName;
         this.sourceJob = job.getId();
         this.locked = true;
         this.creationDate = new Date();
         this.importMethod = ImagesCollectionImportMethod.JOB;
+        this.format = format;
     }
-    
+
     public ImagesCollection(String name, String sourceCatalog){
+        this(name, sourceCatalog, ImagesCollectionFormat.OMETIFF);
+    }
+    public ImagesCollection(String name, String sourceCatalog, ImagesCollectionFormat format){
         this.name = name;
         this.locked = true;
         this.creationDate = new Date();	
         this.sourceCatalog = sourceCatalog;
         this.importMethod = ImagesCollectionImportMethod.CATALOG;
+        this.format = format;
     }
 
     public String getId() {
@@ -212,7 +228,17 @@ public class ImagesCollection extends Data {
 	public void setImportMethod(ImagesCollectionImportMethod importMethod) {
 		this.importMethod = importMethod;
 	}
+
+    public ImagesCollectionFormat getFormat() {
+        return format;
+    }
+
+    public void setFormat(ImagesCollectionFormat format) {
+        this.format = format;
+    }
 	
     public enum ImagesCollectionImportMethod {UPLOADED, JOB, CATALOG, BACKEND_IMPORT}
+
+    public enum ImagesCollectionFormat {OMETIFF, OMEZARR, RAW}
 
 }

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/ImagesCollectionEventHandler.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/ImagesCollectionEventHandler.java
@@ -73,8 +73,6 @@ public class ImagesCollectionEventHandler {
 
         // Set the owner to the connected user
         imagesCollection.setOwner(SecurityContextHolder.getContext().getAuthentication().getName());
-        System.out.println(SecurityContextHolder.getContext().getAuthentication().getAuthorities());
-
         
         // Default import method is UPLOADED
         if (imagesCollection.getImportMethod() == null) {
@@ -84,6 +82,11 @@ public class ImagesCollectionEventHandler {
         // Assert source import folder is not empty and exists if import method is BACKEND_IMPORT
         if(imagesCollection.getImportMethod().equals(ImagesCollectionImportMethod.BACKEND_IMPORT)) {
             imagesCollectionLogic.assertCollectionBackendImportSourceNotEmpty(imagesCollection);
+        }
+
+        // Default conversion format is OMETIFF
+        if (imagesCollection.getFormat() == null) {
+            imagesCollection.setFormat(ImagesCollection.ImagesCollectionFormat.OMETIFF);
         }
         
         // Collections from Catalog are locked by default

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/ImagesCollectionEventHandler.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/ImagesCollectionEventHandler.java
@@ -190,8 +190,8 @@ public class ImagesCollectionEventHandler {
     @HandleAfterDelete
     public void handleAfterDelete(ImagesCollection imagesCollection) {
     	// Delete all images and metadataFiles from deleted collection
-    	imageRepository.deleteAll(imagesCollection.getId(), false);
-    	metadataFileRepository.deleteAll(imagesCollection.getId(), false);
+    	imageRepository.deleteAll(imagesCollection.getId());
+    	metadataFileRepository.deleteAll(imagesCollection.getId());
     	File imagesCollectionFolder = new File (config.getImagesCollectionsFolder(), imagesCollection.getId());
     	try {
     		FileUtils.deleteDirectory(imagesCollectionFolder);

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageController.java
@@ -119,13 +119,11 @@ public class ImageController {
     public DownloadUrl requestImageDownload(
             @PathVariable("imagesCollectionId") String imagesCollectionId,
             @PathVariable("fileName") String fileName) {
-    	System.out.println("enter request download");
         // Generate and send unique download URL
         String tokenParam = generateDownloadTokenParam(imagesCollectionId);
         String imagePath = "/" + fileName;
         String downloadLink = linkTo(ImageController.class,
         		imagesCollectionId).toString() + imagePath + tokenParam;
-        System.out.println(downloadLink);
         return new DownloadUrl(downloadLink);
     }
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageController.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageController.java
@@ -213,7 +213,7 @@ public class ImageController {
         return imageHandler.getOmeXml(imagesCollectionId, fileName);
     }
 
-    @RequestMapping(value = "filterByFileNameRegex", method = RequestMethod.GET)
+    @RequestMapping(value = "/filterByFileNameRegex", method = RequestMethod.GET)
     @PreAuthorize("hasRole('admin') or @imagesCollectionSecurity.checkAuthorize(#imagesCollectionId, false)")
     public HttpEntity<PagedModel<EntityModel<Image>>> getFilesMatchingRegexPage(
             @PathVariable("imagesCollectionId") String imagesCollectionId,

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageConversionService.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageConversionService.java
@@ -147,22 +147,8 @@ public class ImageConversionService extends FileUploadBase{
 		}
 	}
 	
-	public static void convertToTiledOmeTiff(Path inputFile, Path outputFile) throws DependencyException, FormatException, IOException, ServiceException {
-//		TiledOmeTiffConverter tiledOmeTiffConverter = new TiledOmeTiffConverter(
-//				inputFile.toString(),
-//				outputFile.toString(),
-//				CoreConfig.TILE_SIZE,
-//				CoreConfig.TILE_SIZE);
-//		try {
-//	    	tiledOmeTiffConverter.init();
-//	    	tiledOmeTiffConverter.readWriteTiles();
-//	    }
-//	    catch(Exception e) {
-//	      throw new IOException("Cannot convert image to OME TIFF.", e);
-//	    }
-//	    finally {
-//	    	tiledOmeTiffConverter.cleanup();
-//	    }
+	public static void convertToTiledOmeTiff(Path inputFile, Path outputFile) throws DependencyException, FormatException,
+			IOException, ServiceException {
 		String omeTiffOutputName = outputFile.toString();
 		String omeZarrOutputName = omeTiffOutputName.substring(0, omeTiffOutputName.lastIndexOf('.')) + ".zarr";
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageConversionService.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageConversionService.java
@@ -24,10 +24,12 @@ import java.util.logging.Logger;
 import com.glencoesoftware.bioformats2raw.Converter;
 import com.glencoesoftware.pyramid.CompressionType;
 import com.glencoesoftware.pyramid.PyramidFromDirectoryWriter;
+import gov.nist.itl.ssd.wipp.backend.core.utils.SecurityUtils;
 import jakarta.annotation.PostConstruct;
 
 import org.apache.commons.io.FilenameUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import gov.nist.itl.ssd.wipp.backend.core.CoreConfig;
@@ -68,8 +70,10 @@ public class ImageConversionService extends FileUploadBase{
 				appConfig.getOmeConverterThreads());
 
 		// Resume any interrupted conversion
+		SecurityUtils.runAsSystem();
 		imageRepository.findByImporting(true)
 		.forEach(this::submitImageToExtractor);
+		SecurityContextHolder.clearContext();
 	}
 
 	@Override

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageConversionService.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageConversionService.java
@@ -15,11 +15,15 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.glencoesoftware.bioformats2raw.Converter;
+import com.glencoesoftware.pyramid.CompressionType;
+import com.glencoesoftware.pyramid.PyramidFromDirectoryWriter;
 import jakarta.annotation.PostConstruct;
 
 import org.apache.commons.io.FilenameUtils;
@@ -33,6 +37,8 @@ import gov.nist.itl.ssd.wipp.backend.data.imagescollection.files.FileUploadBase;
 import loci.common.services.DependencyException;
 import loci.common.services.ServiceException;
 import loci.formats.FormatException;
+import org.springframework.util.FileSystemUtils;
+import picocli.CommandLine;
 
 
 /**
@@ -129,20 +135,51 @@ public class ImageConversionService extends FileUploadBase{
 	}
 	
 	public static void convertToTiledOmeTiff(Path inputFile, Path outputFile) throws DependencyException, FormatException, IOException, ServiceException {
-		TiledOmeTiffConverter tiledOmeTiffConverter = new TiledOmeTiffConverter(
-				inputFile.toString(),
-				outputFile.toString(), 
-				CoreConfig.TILE_SIZE, 
-				CoreConfig.TILE_SIZE);
+//		TiledOmeTiffConverter tiledOmeTiffConverter = new TiledOmeTiffConverter(
+//				inputFile.toString(),
+//				outputFile.toString(),
+//				CoreConfig.TILE_SIZE,
+//				CoreConfig.TILE_SIZE);
+//		try {
+//	    	tiledOmeTiffConverter.init();
+//	    	tiledOmeTiffConverter.readWriteTiles();
+//	    }
+//	    catch(Exception e) {
+//	      throw new IOException("Cannot convert image to OME TIFF.", e);
+//	    }
+//	    finally {
+//	    	tiledOmeTiffConverter.cleanup();
+//	    }
+		String omeTiffOutputName = outputFile.toString();
+		String omeZarrOutputName = omeTiffOutputName.substring(0, omeTiffOutputName.lastIndexOf('.')) + ".zarr";
+
 		try {
-	    	tiledOmeTiffConverter.init();
-	    	tiledOmeTiffConverter.readWriteTiles();
-	    }
-	    catch(Exception e) {
-	      throw new IOException("Cannot convert image to OME TIFF.", e);
-	    }
-	    finally {
-	    	tiledOmeTiffConverter.cleanup();
-	    }
+	    	// First convert to OME NGFF/ZARR pyramid (downsampling step)
+	    	String[] converterArgs = new String[]{
+	    			inputFile.toString(),
+	    			omeZarrOutputName,
+	    			"--tile-height", String.valueOf(CoreConfig.TILE_SIZE),
+	    			"--tile-width", String.valueOf(CoreConfig.TILE_SIZE),
+	    	};
+	    	CommandLine.call(new Converter(), converterArgs);
+
+	    	// Then convert to OME TIFF pyramid
+	    	String[] converterPyrArgs = new String[]{
+	    			omeZarrOutputName,
+	    			outputFile.toString(),
+	    			"--rgb",
+	    			"--compression", "LZW",
+	    	};
+	    	CommandLine.call(new PyramidFromDirectoryWriter(), converterPyrArgs);
+
+		} catch (Exception e) {
+	    	throw new IOException("Cannot convert image to OME TIFF.", e);
+	    } finally {
+	    	// cleanup temporary OME ZARR directory
+	    	Path omeZarrDir = Paths.get(omeZarrOutputName);
+	    	if(Files.exists(omeZarrDir)) {
+	    		FileSystemUtils.deleteRecursively(omeZarrDir);
+	    	}
+		}
 	}
 }

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageConversionService.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageConversionService.java
@@ -25,6 +25,7 @@ import com.glencoesoftware.bioformats2raw.Converter;
 import com.glencoesoftware.pyramid.CompressionType;
 import com.glencoesoftware.pyramid.PyramidFromDirectoryWriter;
 import gov.nist.itl.ssd.wipp.backend.core.utils.SecurityUtils;
+import gov.nist.itl.ssd.wipp.backend.data.imagescollection.ImagesCollection;
 import jakarta.annotation.PostConstruct;
 
 import org.apache.commons.io.FilenameUtils;
@@ -88,6 +89,14 @@ public class ImageConversionService extends FileUploadBase{
 
 	public void submitImageToExtractor(Image image, File sourceDir) {
 		String collectionId = image.getImagesCollection();
+		ImagesCollection imgCollection = imagesCollectionRepository.findById(collectionId).orElse(null);
+		// if images collection not found, image should be deleted to avoid inconsistent state
+		if (imgCollection == null) {
+		    LOG.warning("Images Collection not found for image " + image.getFileName()
+			    + " while attempting to convert, deleting.");
+		    imageRepository.delete(image);
+		    return;
+		}
 		File tempUploadDir = sourceDir;
 		File uploadDir = getUploadDir(image.getImagesCollection());
 		uploadDir.mkdirs();

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageHandler.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageHandler.java
@@ -13,6 +13,7 @@ package gov.nist.itl.ssd.wipp.backend.data.imagescollection.images;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -89,6 +90,14 @@ public class ImageHandler extends FileHandler {
         imageRepository.deleteByImagesCollectionAndFileName(
                 imagesCollectionId, fileName);
         imagesCollectionRepository.updateImagesCaches(imagesCollectionId);
+    }
+
+    public void importFolderForConversion(String imagesCollectionId, File folder)
+            throws IOException {
+        addAllInDbFromFolder(imagesCollectionId, folder.getPath());
+        File imagesFolder = getTempFilesFolder(imagesCollectionId);
+        imagesFolder.getParentFile().mkdirs();
+        Files.move(folder.toPath(), imagesFolder.toPath());
     }
 
     public String getOmeXml(String imagesCollectionId, String fileName)

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageRepository.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/imagescollection/images/ImageRepository.java
@@ -31,7 +31,7 @@ public interface ImageRepository extends MongoRepository<Image, String>,
 
     List<Image> findByImagesCollectionAndFileNameRegex(String imagesCollection, String fileName);
 
-    Page<Image> findByImagesCollectionAndFileNameRegex(String imagesCollection, String fileName, Pageable p);
+    Page<Image> findByImagesCollectionAndFileNameRegex(String imagesCollection, String regex, Pageable p);
 
     List<Image> findByImporting(boolean importing);
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/utils/tiledtiffs/TiledOmeTiffConverter.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/utils/tiledtiffs/TiledOmeTiffConverter.java
@@ -43,19 +43,12 @@ public class TiledOmeTiffConverter {
 
 	private static final Logger LOG = Logger.getLogger(TiledOmeTiffConverter.class.getName());
 
-	private static final int SCALE_FACTOR = 2;
-
 	private ImageReader reader;
 	private OMETiffWriter writer;
-
-	private OMEPyramidStore omexml;
-	private IImageScaler scaler;
 	private String inputFile;
 	private String outputFile;
 	private int tileSizeX;
 	private int tileSizeY;
-
-	private int numResolutions;
 
 	public TiledOmeTiffConverter(String inputFile, String outputFile, int tileSizeX, int tileSizeY) {
 		this.inputFile = inputFile;
@@ -68,43 +61,30 @@ public class TiledOmeTiffConverter {
 		// construct the object that stores OME-XML metadata
 		ServiceFactory factory = new ServiceFactory();
 		OMEXMLService service = factory.getInstance(OMEXMLService.class);
-		//IMetadata omexml = service.createOMEXMLMetadata();
-		omexml = (OMEPyramidStore) service.createOMEXMLMetadata();
+		IMetadata omexml = service.createOMEXMLMetadata();
 
 		// set up the reader 
 		reader = new ImageReader();
 		// force reader to not group in multi-file formats to treat each file individually
 	    reader.setGroupFiles(false);
 		// set metadata 
-		//reader.setOriginalMetadataPopulated(true);
+		reader.setOriginalMetadataPopulated(true);
 		reader.setMetadataStore(omexml);
 		// set input file
 		reader.setId(inputFile);
-
-		//reader = new ChannelMerger(reader);
 
 		// important to delete because OME uses RandomAccessFile
 		Path outputPath = Paths.get(outputFile);
 		outputPath.toFile().delete();
 
-		// set simple image scaler for downscaling
-		scaler = new SimpleImageScaler();
-
 		// set up the writer and associate it with the output file
 		writer = new OMETiffWriter();
 		writer.setMetadataRetrieve(omexml);
-		//writer.setInterleaved(reader.isInterleaved());
+		writer.setInterleaved(reader.isInterleaved());
 
 		// set the tile size height and width for writing
 		this.tileSizeX = writer.setTileSizeX(tileSizeX);
 		this.tileSizeY = writer.setTileSizeY(tileSizeY);
-
-		this.numResolutions = 1;
-		for (int i=1; i<5; i++) {
-			int divScale = (int) Math.pow(SCALE_FACTOR, i);
-			omexml.setResolutionSizeX(new PositiveInteger(reader.getSizeX() / divScale), 0, i);
-			omexml.setResolutionSizeY(new PositiveInteger(reader.getSizeY() / divScale), 0, i);
-		}
 
 		writer.setId(outputFile);
 
@@ -112,7 +92,7 @@ public class TiledOmeTiffConverter {
 		writer.setCompression(CompressionType.LZW.getCompression());
 	}
 
-	// Read the input file as a plain image and write it into a pyramidal OME tiled format
+	// Read the input file as a plain image and write it into a tiled format
 	public void readWriteTiles() throws FormatException, DependencyException, ServiceException, IOException {
 		int bpp = FormatTools.getBytesPerPixel(reader.getPixelType());
 		int tilePlaneSize = tileSizeX * tileSizeY * reader.getRGBChannelCount() * bpp;
@@ -127,19 +107,12 @@ public class TiledOmeTiffConverter {
 			int width = reader.getSizeX();
 			int height = reader.getSizeY();
 
-			LOG.info("Image height: " + height);
-			LOG.info("Image width: " + width);
-	
 			// Determined the number of tiles to read and write
 			int nXTiles = width / tileSizeX;
 			int nYTiles = height / tileSizeY;
 			if (nXTiles * tileSizeX != width) nXTiles++;
 			if (nYTiles * tileSizeY != height) nYTiles++;
 
-			LOG.info("Full res nXTiles: " + nXTiles);
-			LOG.info("Full res nYTiles: " + nYTiles);
-
-			// write full resolution image in tiles
 			for (int y=0; y<nYTiles; y++) {
 				for (int x=0; x<nXTiles; x++) {
 					
@@ -152,51 +125,6 @@ public class TiledOmeTiffConverter {
 					buf = reader.openBytes(image, tileX, tileY, effTileSizeX, effTileSizeY);
 					writer.saveBytes(image, buf, tileX, tileY, effTileSizeX, effTileSizeY);
 				}
-			}
-
-			// write downscaled pyramid resolutions
-			int resolutionInd = 1;
-			for (int i=1; i<5; i++) {
-
-				writer.setResolution(i);
-				int divScale = (int) Math.pow(SCALE_FACTOR, i);
-
-				width /= SCALE_FACTOR;
-				height /= SCALE_FACTOR;
-
-				LOG.info("*** Resolution " + i);
-				LOG.info("divScale " + divScale);
-				LOG.info("Image height: " + height);
-				LOG.info("Image width: " + width);
-
-				// Determined the number of tiles to read and write
-				nXTiles = width / tileSizeX;
-				nYTiles = height / tileSizeY;
-				if (nXTiles * tileSizeX != width) nXTiles++;
-				if (nYTiles * tileSizeY != height) nYTiles++;
-
-				int resScale = (int) Math.pow(SCALE_FACTOR, i);
-
-				for (int y=0; y<nYTiles; y++) {
-					for (int x=0; x<nXTiles; x++) {
-
-						int tileX = x * tileSizeX;
-						int tileY = y * tileSizeY;
-
-						int effTileSizeX = (tileX + tileSizeX) < width ? tileSizeX : width - tileX;
-						int effTileSizeY = (tileY + tileSizeY) < height ? tileSizeY : height - tileY;
-
-						byte[] newBuf = reader.openBytes(image, tileX * resScale, tileY * resScale, effTileSizeX * resScale, effTileSizeY * resScale);
-
-						byte[] downsample = scaler.downsample(newBuf, effTileSizeX * resScale,
-								effTileSizeY * resScale, Math.pow(SCALE_FACTOR, i),
-								FormatTools.getBytesPerPixel(bpp), reader.isLittleEndian(),
-								FormatTools.isFloatingPoint(bpp), reader.getRGBChannelCount(),
-								reader.isInterleaved());
-						writer.saveBytes(image, downsample, tileX, tileY, effTileSizeX, effTileSizeY);
-					}
-				}
-
 			}
 		}
 	}

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/Visualization.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/Visualization.java
@@ -40,6 +40,8 @@ public class Visualization {
     private Manifest manifest;
 
     private boolean publiclyShared;
+
+    private boolean iiifDataSource;
     
     public Visualization() {
     	
@@ -93,4 +95,8 @@ public class Visualization {
     public void setPubliclyShared(boolean publiclyShared) {
         this.publiclyShared = publiclyShared;
     }
+
+    public boolean isIiifDataSource() { return iiifDataSource; }
+
+    public void setIiifDataSource(boolean iiifDataSource) { this.iiifDataSource = iiifDataSource; }
 }

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/VisualizationEventHandler.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/VisualizationEventHandler.java
@@ -46,6 +46,9 @@ public class VisualizationEventHandler {
         
         // Set the owner to the connected user
         visualization.setOwner(SecurityContextHolder.getContext().getAuthentication().getName());
+
+        // Set the data source to IIIF (default in versions 3.2 and up)
+        visualization.setIiifDataSource(true);
     }
 	
 	@HandleBeforeSave

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/BaseUrlManualRefDeserializer.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/BaseUrlManualRefDeserializer.java
@@ -17,6 +17,7 @@ import gov.nist.itl.ssd.wipp.backend.core.rest.ManualRefDeserializer;
  *
  * @author Mylene Simon <mylene.simon at nist.gov>
  */
+@Deprecated
 public class BaseUrlManualRefDeserializer extends ManualRefDeserializer {
 
     public BaseUrlManualRefDeserializer() {

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/BaseUrlManualRefSerializer.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/BaseUrlManualRefSerializer.java
@@ -46,24 +46,26 @@ public class BaseUrlManualRefSerializer extends JsonSerializer<String> {
 	public void serialize(String value, JsonGenerator gen, SerializerProvider sp)
 			throws IOException, JsonProcessingException {
 		if (value != null) {
-			Link link = entityLinks.linkToItemResource(
-                    Pyramid.class,
-                    value
-            );
-			
-			if (link != null) {
+			if (value.contains("/")) { // not a pyramid id, serialize as regular string
+				gen.writeString(value);
+			} else {
+				Link link = entityLinks.linkToItemResource(
+						Pyramid.class,
+						value
+				);
+
 				// replace standard link by custom one for pyramids
 				String selfUri = link.getHref();
-		        String pyramidBaseUri = CoreConfig.BASE_URI + "/pyramids/"
-		                + value;
+				String pyramidBaseUri = CoreConfig.BASE_URI + "/pyramids/"
+						+ value;
 
-		        String baseUri = selfUri.replace(pyramidBaseUri,
-		        		CoreConfig.PYRAMIDS_BASE_URI + "/"
-		                + value);
+				String baseUri = selfUri.replace(pyramidBaseUri,
+						CoreConfig.PYRAMIDS_BASE_URI + "/"
+								+ value);
 				gen.writeString(baseUri);
 			}
+
 		}
-		
 	}
 
 }

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/DisplayConfig.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/DisplayConfig.java
@@ -1,0 +1,34 @@
+package gov.nist.itl.ssd.wipp.backend.data.visualization.manifest.layers;
+
+public class DisplayConfig {
+
+    private String contrast;
+
+    private String colorMap;
+
+    private String invert;
+
+    public String getContrast() {
+        return contrast;
+    }
+
+    public void setContrast(String contrast) {
+        this.contrast = contrast;
+    }
+
+    public String getColorMap() {
+        return colorMap;
+    }
+
+    public void setColorMap(String colorMap) {
+        this.colorMap = colorMap;
+    }
+
+    public String getInvert() {
+        return invert;
+    }
+
+    public void setInvert(String invert) {
+        this.invert = invert;
+    }
+}

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/Layer.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/Layer.java
@@ -26,9 +26,7 @@ public class Layer {
 	private String id;
 	
 	private String name;
-	
-	//@ManualRef(Pyramid.class)
-	//@JsonDeserialize(using = BaseUrlManualRefDeserializer.class)
+
 	@JsonSerialize(using = BaseUrlManualRefSerializer.class)
 	private String baseUrl;
 

--- a/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/Layer.java
+++ b/wipp-backend-data/src/main/java/gov/nist/itl/ssd/wipp/backend/data/visualization/manifest/layers/Layer.java
@@ -28,9 +28,13 @@ public class Layer {
 	private String name;
 	
 	//@ManualRef(Pyramid.class)
-	@JsonDeserialize(using = BaseUrlManualRefDeserializer.class)
+	//@JsonDeserialize(using = BaseUrlManualRefDeserializer.class)
 	@JsonSerialize(using = BaseUrlManualRefSerializer.class)
 	private String baseUrl;
+
+	private String imagesCollectionId;
+
+	private String filenamePattern;
 	
 	private boolean singleFrame;
 	
@@ -53,6 +57,8 @@ public class Layer {
 	private Scalebar scalebar;
 	
 	private Fetching fetching;
+
+	private DisplayConfig displayConfig;
 
 	public String getId() {
 		return id;
@@ -77,6 +83,14 @@ public class Layer {
 	public void setBaseUrl(String baseUrl) {
 		this.baseUrl = baseUrl;
 	}
+
+	public String getImagesCollectionId() { return imagesCollectionId; }
+
+	public void setImagesCollectionId(String imagesCollectionId) { this.imagesCollectionId = imagesCollectionId; }
+
+	public String getFilenamePattern() { return filenamePattern; }
+
+	public void setFilenamePattern(String filenamePattern) { this.filenamePattern = filenamePattern; }
 
 	public boolean isSingleFrame() {
 		return singleFrame;
@@ -165,7 +179,9 @@ public class Layer {
 	public void setFetching(Fetching fetching) {
 		this.fetching = fetching;
 	}
-	
-	
+
+	public DisplayConfig getDisplayConfig() { return displayConfig; }
+
+	public void setDisplayConfig(DisplayConfig displayConfig) { this.displayConfig = displayConfig; }
 
 }


### PR DESCRIPTION
<!--
Please fill in the following template, and make sure your are following the contributing guidelines before submitting this PR
-->

## What does this PR do?

- OME TIFF conversion now converts to pyramidal OME TIFF using two-step conversion (bioformats2raw followed by raw2ometiff converters)
- Output images from jobs now go through the conversion pipeline
- Added image format to images collections (RAW, OMETIFF, OMEZARR, default to OMETIFF) to prepare for additional conversion options
- Modified pyramid visualizations to default to IIIF/IIP-based tiles, kept retro-compatibility with existing DZI pyramids
- Fixes:
  - Security config fix in Swagger/OpenAPI spec
  - Image search by pattern endpoint bug fix
  - Fix missing security context when image conversions are resumed at startup
  - Fix cascade image deletion when deleting image collection, handling of orphaned images


